### PR TITLE
Remove rustc path hack from CI scripts - no longer needed

### DIFF
--- a/script/build-all.sh
+++ b/script/build-all.sh
@@ -2,16 +2,6 @@
 
 set -euo pipefail
 
-if [[ -z $(which rustc) ]]; then
-  # Transitive dependency `libudev-sys` invokes `rustc` directly on the command
-  # line in its build script - this makes sure it uses the bazel-provided
-  # version.
-
-  # shellcheck disable=SC2147
-  RUSTC_PATH="$(bazel info output_base)/external/rules_rust~~rust_host_tools~rust_host_tools/bin/rustc"
-  ln -sf "${RUSTC_PATH}" /usr/local/bin/rustc
-fi
-
 OPTIONAL_CI_FLAGS=""
 if [[ -n "${CI-}" ]]; then
   # See .bazel/ci.bazelrc for related Bazel flags:

--- a/script/test-all.sh
+++ b/script/test-all.sh
@@ -2,16 +2,6 @@
 
 set -euo pipefail
 
-if [[ -z $(which rustc) ]]; then
-  # Transitive dependency `libudev-sys` invokes `rustc` directly on the command
-  # line in its build script - this makes sure it uses the bazel-provided
-  # version.
-
-  # shellcheck disable=SC2147
-  RUSTC_PATH="$(bazel info output_base)/external/rules_rust~~rust_host_tools~rust_host_tools/bin/rustc"
-  ln -sf "${RUSTC_PATH}" /usr/local/bin/rustc
-fi
-
 OPTIONAL_CI_FLAGS=""
 if [[ -n "${CI-}" ]]; then
   # See .bazel/ci.bazelrc for related Bazel flags:


### PR DESCRIPTION
Went with overriding `libudev-sys` with a locally patched copy instead in https://github.com/kofi-q/vxsweet/pull/5, so this shouldn't be needed anymore.