### PR TITLE
[circleci] Add Dockerfile for CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Docker Image for CI
+
+FROM bitnami/minideb:bookworm
+
+ENV BAZELISK_VERSION=1.21.0
+
+# Essentials
+RUN apt update && apt install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  git \
+  sudo \
+  tar \
+  xz-utils
+
+# Bazel (via Bazelisk):
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+  curl -L -o bazel "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-${ARCH}" && \
+  chmod +x bazel && \
+  mv ./bazel /usr/local/bin/bazel
+
+# VxSuite transitive deps:
+RUN sudo apt update && apt install -y --no-install-recommends \
+  build-essential \
+  g++ \
+  gcc \
+  libasound2  \
+  libatspi2.0-0 \
+  libcairo2-dev \
+  libdrm2\
+  libgbm1 \
+  libgif-dev \
+  libglib2.0-bin \
+  libgtk-3-0 \
+  libjpeg-dev \
+  libnotify4 \
+  libpango1.0-dev \
+  libpcsclite-dev \
+  libpcsclite1 \
+  libpixman-1-dev \
+  libpng-dev \
+  libsane \
+  libsane-common \
+  libsane-hpaio \
+  libsane1 \
+  libudev-dev \
+  libusb-1.0-0-dev \
+  libxss1 \
+  libxtst6 \
+  libzbar-dev \
+  linux-kbuild-6.1 \
+  make \
+  pkg-config \
+  poppler-utils \
+  python3 \
+  zip

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,23 @@
+# To spin up a mirror of the CI environment, run:
+# ```
+#   docker compose run --build --rm -i ci_env
+# ```
+# The `bazel` command will be available on the command line and changes made in
+# the local workspace will be reflected in the docker container.
+
+services:
+  ci_env:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /root/vxsweet
+    volumes:
+      - ./:/root/vxsweet
+      - bazel_cache:/root/.cache/bazel/
+      - bazelisk_cache:/root/.cache/bazelisk/
+      - playwright_cache:/root/.cache/ms-playwright
+
+volumes:
+  bazel_cache: null
+  bazelisk_cache: null
+  playwright_cache: null


### PR DESCRIPTION
Adding a minimal Docker image for CI, along with a `compose` config for spinning up a local mirror of the CI environment for debugging CI runs.

Managed to get the image down to `~360MB`, down from `~1.25GB`, since we can do without some runtime/hardware-specific dependencies that aren't needed in the test environment. Also, a lot of the toolchain installation (node, rust, etc) is now handled by Bazel.