### PR TITLE
Run Rust tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,8 @@ commands:
     steps:
       - run:
           name: Build and Test
-          # TODO: Update to `bazel test` when tests are ready:
           command: |
-            bazel build //... --config=ci
+            bazel test //... --config=ci
 
   save_test_outputs:
     description: Save test logs and artifacts

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -124,13 +124,16 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
 mod test {
     use super::*;
     use image::DynamicImage;
+    use std::env;
     use std::fs::read_dir;
 
     macro_rules! fixture_test {
         ($test_name:ident, $path:expr, $expected:expr) => {
             #[test]
             fn $test_name() {
-                let paths = read_dir($path).unwrap();
+                let paths =
+                    read_dir(PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join($path))
+                        .unwrap();
                 for path in paths {
                     let path = path.unwrap().path();
                     let img = image::open(&path)
@@ -169,10 +172,13 @@ mod test {
 
     #[test]
     fn test_non_blank_paper_fails() {
-        let img = image::open("./test/fixtures/all-bubble-side-a.jpeg")
-            .ok()
-            .map(DynamicImage::into_luma8)
-            .unwrap();
+        let img = image::open(
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+                .join("./test/fixtures/all-bubble-side-a.jpeg"),
+        )
+        .ok()
+        .map(DynamicImage::into_luma8)
+        .unwrap();
         assert!(!blank_paper(img, None));
     }
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -653,6 +653,7 @@ where
 #[allow(clippy::similar_names, clippy::unwrap_used)]
 mod test {
     use std::{
+        env,
         fs::File,
         io::BufReader,
         path::{Path, PathBuf},
@@ -683,7 +684,8 @@ mod test {
         fixture_name: &str,
         (side_a_name, side_b_name): (&str, &str),
     ) -> (GrayImage, GrayImage, Options) {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
+        let fixture_path =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("test/fixtures");
         let election_path = fixture_path.join(fixture_name).join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
@@ -705,7 +707,7 @@ mod test {
         fixture_name: &str,
         starting_page_number: usize,
     ) -> (GrayImage, GrayImage, Options) {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        let fixture_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("../hmpb/fixtures/")
             .join(fixture_name);
         let election_path = fixture_path.join("election.json");

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
@@ -213,6 +213,7 @@ pub fn detect(img: &GrayImage, debug: &ImageDebugWriter) -> Result {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use std::env;
     use std::path::PathBuf;
     use types_rs::geometry::Rect;
 
@@ -222,7 +223,8 @@ mod test {
 
     #[test]
     fn test_detect_qr_code() {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
+        let fixture_path =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("test/fixtures");
         let scan_side_a_path = fixture_path.join("all-bubble-side-a.jpeg");
         let scan_side_a = image::open(scan_side_a_path).unwrap().into_luma8();
         let qr_code = detect(&scan_side_a, &ImageDebugWriter::disabled()).unwrap();
@@ -239,8 +241,8 @@ mod test {
 
     #[test]
     fn test_detect_qr_code_in_skewed_image() {
-        let fixture_path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures/alameda-test");
+        let fixture_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("test/fixtures/alameda-test");
         let scan_side_a_path = fixture_path.join("scan-skewed-side-a.jpeg");
         let scan_side_b_path = fixture_path.join("scan-skewed-side-b.jpeg");
         detect(

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code_metadata.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code_metadata.rs
@@ -112,7 +112,7 @@ const fn bit_size(n: u32) -> u32 {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use std::{fs::File, io::BufReader, path::PathBuf};
+    use std::{env, fs::File, io::BufReader, path::PathBuf};
 
     use proptest::{
         prop_oneof, proptest,
@@ -123,7 +123,8 @@ mod test {
 
     #[test]
     fn test_decode_metadata_bits() {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures/ashland");
+        let fixture_path =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("test/fixtures/ashland");
         let election_path = fixture_path.join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();

--- a/libs/ballot-interpreter/src/hmpb-rust/template.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/template.rs
@@ -154,14 +154,15 @@ pub fn find_template_grid_and_bubbles(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use std::env;
     use std::path::PathBuf;
 
     use super::find_template_grid_and_bubbles;
 
     #[test]
     fn test_find_template_grid_and_bubbles() {
-        let fixture_path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures/nh-test-ballot");
+        let fixture_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("test/fixtures/nh-test-ballot");
         let template_front_path = fixture_path.join("template-front.jpeg");
         let template_back_path = fixture_path.join("template-back.jpeg");
         let side_a_image = image::open(template_front_path).unwrap().to_luma8();

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -1776,6 +1776,7 @@ pub fn detect_metadata_and_normalize_orientation(
 
 #[cfg(test)]
 mod tests {
+    use std::env;
     use std::path::{Path, PathBuf};
 
     use image::GrayImage;
@@ -1803,8 +1804,8 @@ mod tests {
 
     #[test]
     fn test_ignore_smudged_timing_mark() {
-        let fixture_path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures/nh-test-ballot");
+        let fixture_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("test/fixtures/nh-test-ballot");
         let side_a_path = fixture_path.join("timing-mark-smudge-front.jpeg");
         let side_b_path = fixture_path.join("timing-mark-smudge-back.jpeg");
         let (side_a_image, side_b_image) = load_ballot_card_images(&side_a_path, &side_b_path);


### PR DESCRIPTION
Start running all configured tests (so far, just the Rust tests) in CI.

Had to update tests that compile the `CARGO_MANIFEST_DIR` env var in to the test binaries and make them load it at runtime instead, since Bazel runs tests within a new sandbox on each run to ensure hermeticity.