### PR TITLE
Enable jest runs for packages with simple tests

### DIFF
--- a/apps/mark-scan/backend/src/BUILD.bazel
+++ b/apps/mark-scan/backend/src/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "//:node_modules/fs-extra",
         "//:node_modules/node-hid",
         "//:node_modules/path",
+        "//:node_modules/react",
         "//:node_modules/tmp",
         "//:node_modules/xstate",
         "//:node_modules/zod",

--- a/apps/mark/backend/src/BUILD.bazel
+++ b/apps/mark/backend/src/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//:node_modules/debug",
         "//:node_modules/express",
         "//:node_modules/fs-extra",
+        "//:node_modules/react",
         "//:node_modules/zod",
         "//:types_env",
         "//libs/auth/src",

--- a/libs/api/src/BUILD.bazel
+++ b/libs/api/src/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/testing-library__jest-dom",

--- a/libs/ballot-interpreter/src/BUILD.bazel
+++ b/libs/ballot-interpreter/src/BUILD.bazel
@@ -36,6 +36,7 @@ ts_tests(
         "//:node_modules/@types/testing-library__jest-dom",
         "//:node_modules/@types/tmp",
         "//:node_modules/canvas",
+        "//:node_modules/react",
         "//:node_modules/tmp",
         "//libs/ballot-encoder/src",
         "//libs/ballot-interpreter/src",

--- a/libs/basics/src/BUILD.bazel
+++ b/libs/basics/src/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/bmd-ballot-fixtures/src/BUILD.bazel
+++ b/libs/bmd-ballot-fixtures/src/BUILD.bazel
@@ -26,6 +26,7 @@ ts_tests(
         "//:node_modules/@types/jest",
         "//:node_modules/@types/react",
         "//:node_modules/@types/testing-library__jest-dom",
+        "//:node_modules/react",
         "//libs/basics/src",
         "//libs/bmd-ballot-fixtures/src",
         "//libs/fixtures/src",

--- a/libs/db/BUILD.bazel
+++ b/libs/db/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+js_library(
+    name = "fixtures",
+    data = glob([
+        "test/**/*.sql",
+    ]),
+    tags = ["manual"],
+    visibility = [":__subpackages__"],
+)

--- a/libs/db/src/BUILD.bazel
+++ b/libs/db/src/BUILD.bazel
@@ -18,6 +18,8 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    data = ["//libs/db:fixtures"],
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/db/test/BUILD.bazel
+++ b/libs/db/test/BUILD.bazel
@@ -1,1 +1,0 @@
-# gazelle:js_mono_package

--- a/libs/dev-dock/frontend/src/BUILD.bazel
+++ b/libs/dev-dock/frontend/src/BUILD.bazel
@@ -25,6 +25,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@testing-library/react",
         "//:node_modules/@testing-library/user-event",
@@ -32,6 +33,7 @@ ts_tests(
         "//:node_modules/@types/node",
         "//:node_modules/@types/react",
         "//:node_modules/@types/testing-library__jest-dom",
+        "//:node_modules/react",
         "//:types_kiosk_browser",
         "//libs/auth/src",
         "//libs/dev-dock/backend/src",

--- a/libs/eslint-plugin-vx/tests/fixtures/BUILD.bazel
+++ b/libs/eslint-plugin-vx/tests/fixtures/BUILD.bazel
@@ -5,5 +5,8 @@ json_package(name = "json")
 
 ts_library(
     name = "fixtures",
-    deps = ["//:node_modules/@types/react"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/react",
+    ],
 )

--- a/libs/fujitsu-thermal-printer/src/BUILD.bazel
+++ b/libs/fujitsu-thermal-printer/src/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/grout/src/BUILD.bazel
+++ b/libs/grout/src/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/express",
         "//:node_modules/@types/jest",

--- a/libs/image-test-utils/BUILD.bazel
+++ b/libs/image-test-utils/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/image-utils/test/BUILD.bazel
+++ b/libs/image-utils/test/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/testing-library__jest-dom",

--- a/libs/mark-flow-ui/src/BUILD.bazel
+++ b/libs/mark-flow-ui/src/BUILD.bazel
@@ -50,6 +50,7 @@ ts_stories(
     deps = [
         "//:node_modules/@storybook/react",
         "//:node_modules/@types/react",
+        "//:node_modules/react",
         "//libs/mark-flow-ui/src",
     ],
 )

--- a/libs/mark-flow-ui/test/BUILD.bazel
+++ b/libs/mark-flow-ui/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     deps = [
         "//:node_modules/@testing-library/react",
         "//:node_modules/@types/react",
+        "//:node_modules/react",
         "//libs/ui/src",
     ],
 )

--- a/libs/message-coder/src/BUILD.bazel
+++ b/libs/message-coder/src/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/pdi-scanner/src/ts/BUILD.bazel
+++ b/libs/pdi-scanner/src/ts/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/printing/scripts/BUILD.bazel
+++ b/libs/printing/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_library(
     name = "scripts",
     deps = [
         "//:node_modules/@types/react",
+        "//:node_modules/react",
         "//libs/fs/src",
         "//libs/printing/src",
         "//libs/ui/src",

--- a/libs/printing/src/BUILD.bazel
+++ b/libs/printing/src/BUILD.bazel
@@ -36,6 +36,7 @@ ts_tests(
         "//:node_modules/@types/testing-library__jest-dom",
         "//:node_modules/@types/tmp",
         "//:node_modules/playwright",
+        "//:node_modules/react",
         "//:node_modules/tmp",
         "//libs/basics/src",
         "//libs/fixtures/src",

--- a/libs/test-utils/src/BUILD.bazel
+++ b/libs/test-utils/src/BUILD.bazel
@@ -26,6 +26,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/types/src/BUILD.bazel
+++ b/libs/types/src/BUILD.bazel
@@ -43,6 +43,7 @@ ts_tests(
         "//:node_modules/js-sha256",
         "//:node_modules/lodash.clonedeep",
         "//:node_modules/lodash.set",
+        "//:node_modules/react",
         "//:node_modules/zod",
         "//libs/basics/src",
         "//libs/cdf-schema-builder/src",

--- a/libs/types/test/BUILD.bazel
+++ b/libs/types/test/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/tools/gazelle/ts/kinds.go
+++ b/tools/gazelle/ts/kinds.go
@@ -16,12 +16,10 @@ var (
 			MatchAny: true,
 			SubstituteAttrs: map[string]bool{
 				"deps": true,
-				"data": true,
 			},
 			MergeableAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 			NonEmptyAttrs: map[string]bool{
 				"name": true,
@@ -29,7 +27,6 @@ var (
 			ResolveAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 		},
 
@@ -37,12 +34,10 @@ var (
 			MatchAny: true,
 			SubstituteAttrs: map[string]bool{
 				"deps": true,
-				"data": true,
 			},
 			MergeableAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 			NonEmptyAttrs: map[string]bool{
 				"name": true,
@@ -50,7 +45,6 @@ var (
 			ResolveAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 		},
 
@@ -58,12 +52,10 @@ var (
 			MatchAny: true,
 			SubstituteAttrs: map[string]bool{
 				"deps": true,
-				"data": true,
 			},
 			MergeableAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 			NonEmptyAttrs: map[string]bool{
 				"name": true,
@@ -71,7 +63,6 @@ var (
 			ResolveAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 		},
 
@@ -79,12 +70,10 @@ var (
 			MatchAny: true,
 			SubstituteAttrs: map[string]bool{
 				"deps": true,
-				"data": true,
 			},
 			MergeableAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 			NonEmptyAttrs: map[string]bool{
 				"name": true,
@@ -92,7 +81,6 @@ var (
 			ResolveAttrs: map[string]bool{
 				"name": true,
 				"deps": true,
-				"data": true,
 			},
 		},
 

--- a/tools/gazelle/ts/parser.go
+++ b/tools/gazelle/ts/parser.go
@@ -141,8 +141,13 @@ func ParseSourceFile(rootDir, filePath string) (ParseResult, []error) {
 		imports["@types/node"] = true
 	}
 
-	if extension == ".tsx" || regexReactTypes.Match([]byte(stringContent)) {
+	if regexReactTypes.Match([]byte(stringContent)) {
 		imports["@types/react"] = true
+	}
+
+	if extension == ".tsx" {
+		imports["@types/react"] = true
+		imports["react"] = true
 	}
 
 	return ParseResult{


### PR DESCRIPTION
Enabling tests that mostly pass on the first attempt.

Also fixing a bug in the Gazelle plugin that overwrites manually entered `data` attributes in the `BUILD` files.