### PR TITLE
Enable Jest tests in libs/auth

### DIFF
--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -23,6 +23,8 @@ import { makeIdFactory } from '../test/id_helpers';
 
 let apiMock: MockApiClient;
 
+jest.setTimeout(20_000);
+
 const idFactory = makeIdFactory();
 
 beforeEach(() => {

--- a/libs/auth/BUILD.bazel
+++ b/libs/auth/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+js_library(
+    name = "certs",
+    data = [
+        "certs/openssl.cnf",
+    ] + glob([
+        "certs/**/*.der",
+        "certs/**/*.pem",
+    ]),
+    tags = ["manual"],
+    visibility = [":__subpackages__"],
+)

--- a/libs/auth/certs/test/BUILD.bazel
+++ b/libs/auth/certs/test/BUILD.bazel
@@ -1,1 +1,0 @@
-# gazelle:js_mono_package

--- a/libs/auth/src/BUILD.bazel
+++ b/libs/auth/src/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("//tools/ts_build:js_binary.bzl", "js_binary")
 load("//tools/ts_build:lint_test.bzl", "lint_test")
 load("//tools/ts_build:ts_library.bzl", "ts_library")
 load("//tools/ts_build:ts_tests.bzl", "ts_tests")
@@ -33,6 +35,10 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    size = "medium",
+    data = [":required_data"],
+    shard_count = 19,
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/luxon",
@@ -60,3 +66,46 @@ ts_tests(
 )
 
 lint_test(name = "lint")
+
+js_library(
+    name = "required_data",
+    data = [
+        ":cac_certs",
+        ":intermediate_scripts",
+        "//libs/auth:certs",
+    ],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+js_library(
+    name = "cac_certs",
+    data = glob([
+        "cac/**/*.pem",
+    ]),
+    tags = ["manual"],
+    visibility = [":__subpackages__"],
+)
+
+js_library(
+    name = "intermediate_scripts",
+    data = [
+        ":create-cert",
+        ":sign-message",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+js_binary(
+    name = "sign-message",
+    src = ":src",
+    entry_point = "intermediate-scripts/sign_message.js",
+    visibility = ["//visibility:public"],
+)
+
+js_binary(
+    name = "create-cert",
+    src = ":src",
+    entry_point = "intermediate-scripts/create_cert.js",
+    visibility = ["//visibility:public"],
+)

--- a/libs/auth/src/cryptography.test.ts
+++ b/libs/auth/src/cryptography.test.ts
@@ -498,13 +498,13 @@ test.each<{
     expect(spawn).toHaveBeenCalledTimes(1);
     if (isSudoExpected) {
       expect(spawn).toHaveBeenNthCalledWith(1, 'sudo', [
-        expect.stringContaining('/src/intermediate-scripts/create-cert'),
+        expect.stringContaining('/src/create-cert'),
         expect.any(String),
       ]);
     } else {
       expect(spawn).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('/src/intermediate-scripts/create-cert'),
+        expect.stringContaining('/src/create-cert'),
         [expect.any(String)]
       );
     }
@@ -634,13 +634,13 @@ test.each<{
   expect(spawn).toHaveBeenCalledTimes(1);
   if (isSudoExpected) {
     expect(spawn).toHaveBeenNthCalledWith(1, 'sudo', [
-      expect.stringContaining('/src/intermediate-scripts/sign-message'),
+      expect.stringContaining('/src/sign-message'),
       expect.any(String),
     ]);
   } else {
     expect(spawn).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('/src/intermediate-scripts/sign-message'),
+      expect.stringContaining('/src/sign-message'),
       [expect.any(String)]
     );
   }

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -404,17 +404,15 @@ export async function createCertHelper({
  *
  * Uses a slightly roundabout control flow for permissions purposes:
  *
- * createCert() --> ../src/intermediate-scripts/create-cert --> createCertHelper()
+ * createCert() --> ../src/create-cert --> createCertHelper()
  *
  * When using TPM keys in production, we need sudo access. Creating the intermediate create-cert
  * script allows us to grant password-less sudo access to the relevant system users for just that
  * operation, instead of having to grant password-less sudo access more globally.
  */
 export async function createCert(input: CreateCertInput): Promise<Buffer> {
-  const scriptPath = path.join(
-    __dirname,
-    '../src/intermediate-scripts/create-cert'
-  );
+  // TODO: Clean this up - use env var?
+  const scriptPath = path.join(__dirname, 'create-cert_/create-cert');
   const scriptInput = JSON.stringify(input);
   const usingTpm = input.signingPrivateKey.source === 'tpm';
   const command = usingTpm
@@ -511,7 +509,7 @@ export async function signMessageHelper({
  *
  * Uses a slightly roundabout control flow for permissions purposes:
  *
- * signMessage() --> ../src/intermediate-scripts/sign-message --> signMessageHelper()
+ * signMessage() --> ../src/sign-message --> signMessageHelper()
  *
  * When using TPM keys in production, we need sudo access. Creating the intermediate sign-message
  * script allows us to grant password-less sudo access to the relevant system users for just that
@@ -521,10 +519,8 @@ export async function signMessage({
   message,
   ...inputExcludingMessage
 }: SignMessageInput): Promise<Buffer> {
-  const scriptPath = path.join(
-    __dirname,
-    '../src/intermediate-scripts/sign-message'
-  );
+  // TODO: Clean this up - use env var?
+  const scriptPath = path.join(__dirname, 'sign-message_/sign-message');
   const scriptInput = JSON.stringify(inputExcludingMessage);
   const usingTpm = inputExcludingMessage.signingPrivateKey.source === 'tpm';
   const command = usingTpm

--- a/libs/auth/src/intermediate-scripts/create-cert
+++ b/libs/auth/src/intermediate-scripts/create-cert
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-require('esbuild-runner').install({
-  type: 'transform',
-});
-require('./create_cert').main();

--- a/libs/auth/src/intermediate-scripts/create_cert.ts
+++ b/libs/auth/src/intermediate-scripts/create_cert.ts
@@ -18,3 +18,5 @@ export async function main(): Promise<void> {
   process.stdout.write(cert);
   process.exit(0);
 }
+
+void main();

--- a/libs/auth/src/intermediate-scripts/sign-message
+++ b/libs/auth/src/intermediate-scripts/sign-message
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-require('esbuild-runner').install({
-  type: 'transform',
-});
-require('./sign_message').main();

--- a/libs/auth/src/intermediate-scripts/sign_message.ts
+++ b/libs/auth/src/intermediate-scripts/sign_message.ts
@@ -23,3 +23,5 @@ export async function main(): Promise<void> {
   process.stdout.write(messageSignature);
   process.exit(0);
 }
+
+void main();

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/card_reader';
 import { CardType } from '../src/certs';
 import { JavaCard } from '../src/java_card';
+import path from 'node:path';
 
 /**
  * A mock card reader
@@ -131,7 +132,13 @@ function isCardSpecificTestFile(
 export function getTestFilePath(testFile: TestFile): string {
   const setId: TestFileSetId = testFile.setId ?? '1';
   if (isCardSpecificTestFile(testFile)) {
-    return `./certs/test/set-${setId}/${testFile.cardType}/${testFile.fileType}`;
+    return path.join(
+      __dirname,
+      `../certs/test/set-${setId}/${testFile.cardType}/${testFile.fileType}`
+    );
   }
-  return `./certs/test/set-${setId}/${testFile.fileType}`;
+  return path.join(
+    __dirname,
+    `../certs/test/set-${setId}/${testFile.fileType}`
+  );
 }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "tmp": "0.2.1",
     "tmp-promise": "3.0.3",
     "tone": "14.7.77",
+    "tsx": "^4.19.1",
     "typescript": "5.6.2",
     "usb": "2.8.3",
     "use-interval": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ dependencies:
   tone:
     specifier: 14.7.77
     version: 14.7.77
+  tsx:
+    specifier: ^4.19.1
+    version: 4.19.1
   typescript:
     specifier: 5.6.2
     version: 5.6.2
@@ -2776,6 +2779,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.23.1:
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-arm64@0.17.11:
     resolution: {integrity: sha512-QnK4d/zhVTuV4/pRM4HUjcsbl43POALU2zvBynmrrqZt9LPcLA3x1fTZPBg2RRguBQnJcnU059yKr+bydkntjg==}
     engines: {node: '>=12'}
@@ -2800,6 +2812,15 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm64@0.23.1:
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/android-arm@0.17.11:
@@ -2828,6 +2849,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-arm@0.23.1:
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-x64@0.17.11:
     resolution: {integrity: sha512-3PL3HKtsDIXGQcSCKtWD/dy+mgc4p2Tvo2qKgKHj9Yf+eniwFnuoQ0OUhlSfAEpKAFzF9N21Nwgnap6zy3L3MQ==}
     engines: {node: '>=12'}
@@ -2852,6 +2882,15 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-x64@0.23.1:
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.17.11:
@@ -2880,6 +2919,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.23.1:
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/darwin-x64@0.17.11:
     resolution: {integrity: sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==}
     engines: {node: '>=12'}
@@ -2904,6 +2952,15 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.23.1:
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.11:
@@ -2932,6 +2989,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.23.1:
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.11:
     resolution: {integrity: sha512-iPgenptC8i8pdvkHQvXJFzc1eVMR7W2lBPrTE6GbhR54sLcF42mk3zBOjKPOodezzuAz/KSu8CPyFSjcBMkE9g==}
     engines: {node: '>=12'}
@@ -2956,6 +3022,15 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.23.1:
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.17.11:
@@ -2984,6 +3059,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-arm64@0.23.1:
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-arm@0.17.11:
     resolution: {integrity: sha512-M9iK/d4lgZH0U5M1R2p2gqhPV/7JPJcRz+8O8GBKVgqndTzydQ7B2XGDbxtbvFkvIs53uXTobOhv+RyaqhUiMg==}
     engines: {node: '>=12'}
@@ -3008,6 +3092,15 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-arm@0.23.1:
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.17.11:
@@ -3036,6 +3129,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-ia32@0.23.1:
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-loong64@0.17.11:
     resolution: {integrity: sha512-aCWlq70Q7Nc9WDnormntGS1ar6ZFvUpqr8gXtO+HRejRYPweAFQN615PcgaSJkZjhHp61+MNLhzyVALSF2/Q0g==}
     engines: {node: '>=12'}
@@ -3060,6 +3162,15 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.23.1:
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.17.11:
@@ -3088,6 +3199,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.23.1:
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.11:
     resolution: {integrity: sha512-BdlziJQPW/bNe0E8eYsHB40mYOluS+jULPCjlWiHzDgr+ZBRXPtgMV1nkLEGdpjrwgmtkZHEGEPaKdS/8faLDA==}
     engines: {node: '>=12'}
@@ -3112,6 +3232,15 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.23.1:
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.17.11:
@@ -3140,6 +3269,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.23.1:
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-s390x@0.17.11:
     resolution: {integrity: sha512-4N5EMESvws0Ozr2J94VoUD8HIRi7X0uvUv4c0wpTHZyZY9qpaaN7THjosdiW56irQ4qnJ6Lsc+i+5zGWnyqWqQ==}
     engines: {node: '>=12'}
@@ -3164,6 +3302,15 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.23.1:
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.17.11:
@@ -3192,6 +3339,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-x64@0.23.1:
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/netbsd-x64@0.17.11:
     resolution: {integrity: sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==}
     engines: {node: '>=12'}
@@ -3216,6 +3372,24 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.23.1:
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.17.11:
@@ -3244,6 +3418,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/sunos-x64@0.17.11:
     resolution: {integrity: sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==}
     engines: {node: '>=12'}
@@ -3268,6 +3451,15 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.23.1:
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.17.11:
@@ -3296,6 +3488,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-arm64@0.23.1:
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-ia32@0.17.11:
     resolution: {integrity: sha512-GFPSLEGQr4wHFTiIUJQrnJKZhZjjq4Sphf+mM76nQR6WkQn73vm7IsacmBRPkALfpOCHsopSvLgqdd4iUW2mYw==}
     engines: {node: '>=12'}
@@ -3322,6 +3523,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-ia32@0.23.1:
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-x64@0.17.11:
     resolution: {integrity: sha512-N9vXqLP3eRL8BqSy8yn4Y98cZI2pZ8fyuHx6lKjiG2WABpT2l01TXdzq5Ma2ZUBzfB7tx5dXVhge8X9u0S70ZQ==}
     engines: {node: '>=12'}
@@ -3346,6 +3556,15 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-x64@0.23.1:
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.57.1):
@@ -9816,6 +10035,38 @@ packages:
       '@esbuild/win32-ia32': 0.21.2
       '@esbuild/win32-x64': 0.21.2
 
+  /esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+    dev: false
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -11142,6 +11393,12 @@ packages:
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true
+
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: false
 
   /get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -16398,7 +16655,6 @@ packages:
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-    dev: true
 
   /resolve-url@0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
@@ -17981,6 +18237,17 @@ packages:
       tslib: 1.14.1
       typescript: 5.6.2
     dev: true
+
+  /tsx@4.19.1:
+    resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}

--- a/tools/ts_build/js_binary.bzl
+++ b/tools/ts_build/js_binary.bzl
@@ -1,0 +1,24 @@
+load("@aspect_rules_js//js:defs.bzl", _js_binary = "js_binary")
+
+def js_binary(
+        name,
+        src,
+        entry_point,
+        data = [],
+        visibility = None):
+    _js_binary(
+        name = name,
+        data = data + [
+            src,
+            "//:node_modules/tsx",
+            "//:tsconfig_base",
+        ],
+        entry_point = entry_point,
+        node_options = [
+            # Run with `tsx` to enable tsconfig-path-based import resolution and
+            # `esbuild`-based runtime transpilation, when needed.
+            "--import",
+            "tsx",
+        ],
+        visibility = visibility,
+    )


### PR DESCRIPTION
Swapped out the bootstrapping scripts for the `intermediate-scripts` for Bazel-generated node-wrapped binaries, which
spawn node processes with an `--import tsx` arg, in place of `esbuild-runner`, since `tsx` essentially provides `esbuild-runner` + `tsconfig-paths`.