### PR TITLE
Libs backend fs tests

### DIFF
--- a/libs/backend/src/BUILD.bazel
+++ b/libs/backend/src/BUILD.bazel
@@ -6,6 +6,7 @@ load("//tools/ts_build:ts_tests.bzl", "ts_tests")
 
 ts_library(
     name = "src",
+    data = ["//libs/auth/src:required_data"],
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/luxon",
@@ -38,6 +39,8 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    shard_count = 22,
+    tmp_enable_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/lodash.set",

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -88,10 +88,12 @@ test('successful import', async () => {
 
 test('authentication error during import', async () => {
   const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
-  fs.appendFileSync(
-    path.join(exportDirectoryPath, CastVoteRecordExportFileName.METADATA),
-    '\n'
+  const filePath = path.join(
+    exportDirectoryPath,
+    CastVoteRecordExportFileName.METADATA
   );
+  fs.chmodSync(filePath, 0o600);
+  fs.appendFileSync(filePath, '\n');
 
   expect(await readCastVoteRecordExport(exportDirectoryPath)).toEqual(
     err({ type: 'authentication-error' })
@@ -117,10 +119,12 @@ test('metadata file parse error during import', async () => {
     BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
   );
   const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
-  fs.appendFileSync(
-    path.join(exportDirectoryPath, CastVoteRecordExportFileName.METADATA),
-    '}'
+  const filePath = path.join(
+    exportDirectoryPath,
+    CastVoteRecordExportFileName.METADATA
   );
+  fs.chmodSync(filePath, 0o600);
+  fs.appendFileSync(filePath, '}');
 
   expect(await readCastVoteRecordExport(exportDirectoryPath)).toEqual(
     err({ type: 'metadata-file-parse-error' })

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -99,11 +99,13 @@ export async function modifyCastVoteRecordExport(
     const { castVoteRecord, castVoteRecordReportContents } = readCastVoteRecord(
       castVoteRecordDirectoryPath
     );
+    const filePath = path.join(
+      castVoteRecordDirectoryPath,
+      CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
+    );
+    fs.chmodSync(filePath, 0o600);
     fs.writeFileSync(
-      path.join(
-        castVoteRecordDirectoryPath,
-        CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
-      ),
+      filePath,
       JSON.stringify({
         ...JSON.parse(castVoteRecordReportContents),
         CVR: [castVoteRecordModifier(castVoteRecord as NotReadOnly<CVR.CVR>)],
@@ -114,11 +116,13 @@ export async function modifyCastVoteRecordExport(
   const metadata = (
     await readCastVoteRecordExportMetadata(modifiedExportDirectoryPath)
   ).unsafeUnwrap();
+  const filePath = path.join(
+    modifiedExportDirectoryPath,
+    CastVoteRecordExportFileName.METADATA
+  );
+  fs.chmodSync(filePath, 0o600);
   fs.writeFileSync(
-    path.join(
-      modifiedExportDirectoryPath,
-      CastVoteRecordExportFileName.METADATA
-    ),
+    filePath,
     JSON.stringify({
       ...metadata,
       castVoteRecordReportMetadata: castVoteRecordReportMetadataModifier(

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -14,6 +14,8 @@ import { createMockUsbDrive } from '@vx/libs/usb-drive/src';
 import { Exporter, ExportDataResult } from './exporter';
 import { execFile } from './exec';
 
+const TMPDIR = process.env.TMPDIR || '/tmp';
+
 const execFileMock = mockOf(execFile);
 const tmpDirs: DirResult[] = [];
 
@@ -27,7 +29,7 @@ const mockUsbDrive = createMockUsbDrive();
 const { usbDrive } = mockUsbDrive;
 
 const exporter = new Exporter({
-  allowedExportPatterns: ['/tmp/**'],
+  allowedExportPatterns: [`${TMPDIR}/**`],
   usbDrive,
 });
 
@@ -190,10 +192,10 @@ test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
     'bucket',
     'test.txt',
     Readable.from('1234'),
-    { machineDirectoryToWriteToFirst: '/tmp/abcd' }
+    { machineDirectoryToWriteToFirst: `${TMPDIR}/abcd` }
   );
   const usbFilePath = join(tmpDir, 'bucket/test.txt');
-  const machineFilePath = '/tmp/abcd/test.txt';
+  const machineFilePath = `${TMPDIR}/abcd/test.txt`;
   expect(result).toEqual(ok([usbFilePath]));
   expect(await readFile(usbFilePath, 'utf-8')).toEqual('1234');
   expect(await readFile(machineFilePath, 'utf-8')).toEqual('1234');

--- a/libs/backend/src/scan_globals.ts
+++ b/libs/backend/src/scan_globals.ts
@@ -1,5 +1,6 @@
 import { unsafeParse } from '@vx/libs/types/src';
 import { DEV_MOCK_USB_DRIVE_GLOB_PATTERN } from '@vx/libs/usb-drive/src';
+import path from 'node:path';
 import { z } from 'zod';
 
 const NodeEnvSchema = z.union([
@@ -23,12 +24,16 @@ export const NODE_ENV = unsafeParse(
 
 const REAL_USB_DRIVE_GLOB_PATTERN = '/media/**/*';
 
+export const TEST_ALLOWED_EXPORT_PATTERNS = [
+  path.join(process.env.TMPDIR || '/tmp/', '**/*'),
+];
+
 const DEFAULT_ALLOWED_EXPORT_PATTERNS =
   NODE_ENV === 'production'
     ? [REAL_USB_DRIVE_GLOB_PATTERN]
     : NODE_ENV === 'development'
     ? [REAL_USB_DRIVE_GLOB_PATTERN, DEV_MOCK_USB_DRIVE_GLOB_PATTERN]
-    : ['/tmp/**/*']; // Where mock USB drives are created within tests
+    : TEST_ALLOWED_EXPORT_PATTERNS; // Where mock USB drives are created within tests
 
 /**
  * Where are exported files allowed to be written to?

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -36,6 +36,8 @@ createReadStreamMock.mockImplementation(realCreateReadStream);
 
 const execFileMock = mockOf(execFile);
 
+const TMPDIR = process.env.TMPDIR || '/tmp';
+
 let logger: Logger;
 
 beforeEach(() => {
@@ -301,7 +303,7 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
 
   expect(execFileMock).toHaveBeenCalledWith('cp', [
     '-r',
-    expect.stringContaining('/tmp/'),
+    expect.stringContaining(`${TMPDIR}`),
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 
@@ -373,7 +375,7 @@ test('exportLogsToUsb works for error format when all conditions are met', async
 
   expect(execFileMock).toHaveBeenCalledWith('cp', [
     '-r',
-    expect.stringContaining('/tmp/'),
+    expect.stringContaining(`${TMPDIR}`),
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 

--- a/libs/fixtures/BUILD.bazel
+++ b/libs/fixtures/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+DATA_FILE_EXTENSIONS = [
+    "csv",
+    "jpeg",
+    "jpg",
+    "json",
+    "jsonl",
+    "pdf",
+    "png",
+    "txt",
+    "xml",
+    "vxsig",
+    "zip",
+]
+
+DATA_FILES = glob(
+    [
+        "data/**/*.{}".format(ext)
+        for ext in DATA_FILE_EXTENSIONS
+    ],
+    allow_empty = True,
+)
+
+js_library(
+    name = "data",
+    data = DATA_FILES,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    DATA_FILES,
+    visibility = ["//visibility:public"],
+)

--- a/libs/fixtures/src/BUILD.bazel
+++ b/libs/fixtures/src/BUILD.bazel
@@ -6,6 +6,7 @@ load("//tools/ts_build:ts_tests.bzl", "ts_tests")
 
 ts_library(
     name = "src",
+    data = ["//libs/fixtures:data"],
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/fs/src/BUILD.bazel
+++ b/libs/fs/src/BUILD.bazel
@@ -16,6 +16,8 @@ ts_library(
 
 ts_tests(
     name = "tests",
+    tmp_enable_tests = True,
+    unsound_disable_node_fs_patch_for_tests = True,
     deps = [
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/fs/src/list_directory.test.ts
+++ b/libs/fs/src/list_directory.test.ts
@@ -1,11 +1,22 @@
-import { err, iter, ok } from '@vx/libs/basics/src';
+import { err, iter, ok, Result } from '@vx/libs/basics/src';
 import { symlinkSync } from 'node:fs';
 import tmp from 'tmp';
 import {
+  FileSystemEntry,
   FileSystemEntryType,
   listDirectory,
+  ListDirectoryError,
   listDirectoryRecursive,
 } from './list_directory';
+
+function sortOkEntries(
+  entries: Array<Result<FileSystemEntry, ListDirectoryError>>
+) {
+  // eslint-disable-next-line vx/no-array-sort-mutation
+  return entries.sort((a, b) =>
+    a.unsafeUnwrap().name.localeCompare(b.unsafeUnwrap().name)
+  );
+}
 
 describe(listDirectory, () => {
   test('happy path', async () => {
@@ -19,7 +30,7 @@ describe(listDirectory, () => {
 
     const results = await iter(listDirectory(directory.name)).toArray();
 
-    expect(results).toMatchObject([
+    expect(sortOkEntries(results)).toMatchObject([
       ok(
         expect.objectContaining({
           name: 'file-1',
@@ -89,7 +100,7 @@ describe(listDirectoryRecursive, () => {
 
     const results = iter(listDirectoryRecursive(directory.name));
 
-    expect(await results.toArray()).toMatchObject([
+    expect(sortOkEntries(await results.toArray())).toMatchObject([
       ok(
         expect.objectContaining({
           name: 'file-1',


### PR DESCRIPTION
Enabling
- libs/fs - required disabling the node fs patches in `rules_js` that keep fs accesses from leaving the sandbox
  - Wasn't absolutely necessary - there's error-handling code that expects exact errors from fs that get translated to consumer-facing errors. Could update that to handle unexpected errors as well, but this works for now.
  - libs/backend - the indirection to data files in `libs/fixtures` was causing some issues here, since Bazel marks non-generated sandbox files as read-only and that attribute gets persisted in the copies the tests make (e.g. via `asDirectoryPath`). Hacked a couple `chmod`s at the file copy points to get around this, but might revisit to see if any of that can be improved.