### PR TITLE
Merge simple PR from upstream to gauge build graph fallout

### DIFF
--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -1,6 +1,7 @@
 import { sliceBallotHashForEncoding } from '@vx/libs/ballot-encoder/src';
 import {
   assert,
+  assertDefined,
   find,
   iter,
   ok,
@@ -26,6 +27,7 @@ import {
   Corners,
   ElectionDefinition,
   getBallotStyle,
+  getContests,
   GridPosition,
   HmpbBallotPageMetadata,
   Id,
@@ -276,7 +278,8 @@ function getUnmarkedWriteInsFromScoredContestOptions(
 export function determineAdjudicationInfoFromBmdVotes(
   electionDefinition: ElectionDefinition,
   options: InterpreterOptions,
-  votes: VotesDict
+  votes: VotesDict,
+  ballotStyleId: BallotStyleId
 ): AdjudicationInfo {
   const bmdAdjudicationReasons = [
     AdjudicationReason.BlankBallot,
@@ -285,10 +288,13 @@ export function determineAdjudicationInfoFromBmdVotes(
   const enabledReasons = options.adjudicationReasons.filter((reason) =>
     bmdAdjudicationReasons.includes(reason)
   );
-  const { contests } = electionDefinition.election;
+  const { election } = electionDefinition;
 
   const adjudicationReasonInfos = getAllPossibleAdjudicationReasonsForBmdVotes(
-    contests,
+    getContests({
+      ballotStyle: assertDefined(getBallotStyle({ ballotStyleId, election })),
+      election,
+    }),
     votes
   );
 
@@ -699,7 +705,8 @@ async function interpretBmdBallot(
   const adjudicationInfo = determineAdjudicationInfoFromBmdVotes(
     electionDefinition,
     options,
-    ballot.votes
+    ballot.votes,
+    ballot.ballotStyleId
   );
 
   const front: InterpretFileResult = {

--- a/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   electionFamousNames2021Fixtures,
   electionGeneralDefinition,
+  electionPrimaryPrecinctSplitsFixtures,
 } from '@vx/libs/fixtures/src';
 import { mockOf } from '@vx/libs/test-utils/src';
 import {
@@ -26,7 +27,10 @@ import {
   SheetOf,
   VotesDict,
   asSheet,
+  getBallotStyle,
+  getContests,
   mapSheet,
+  vote,
 } from '@vx/libs/types/src';
 import {
   ALL_PRECINCTS_SELECTION,
@@ -270,6 +274,64 @@ describe('adjudication reporting', () => {
         (info) => info.type === 'Undervote'
       )
     ).toBeUndefined();
+  });
+
+  test('test adjudication for a primary election', async () => {
+    const { electionDefinition: primaryElectionDefinition } =
+      electionPrimaryPrecinctSplitsFixtures;
+    const { election } = primaryElectionDefinition;
+    const primaryPrecinctId = 'precinct-c1-w1-1';
+    const primaryBallotStyleId = '1-Ma_en' as BallotStyleId;
+    const ballotStyle = getBallotStyle({
+      ballotStyleId: primaryBallotStyleId,
+      election,
+    })!;
+    const votes: VotesDict = vote(getContests({ ballotStyle, election }), {
+      'county-leader-mammal': [], // undervote
+      'congressional-1-mammal': ['zebra-1'],
+      'water-1-fishing': ['water-1-fishing-ban-fishing'],
+    });
+
+    const validBmdSheet = asSheet(
+      await pdfToPageImages(
+        await renderBmdBallotFixture({
+          electionDefinition: primaryElectionDefinition,
+          precinctId: primaryPrecinctId,
+          ballotStyleId: primaryBallotStyleId,
+          votes,
+        })
+      ).toArray()
+    );
+    const [bmdSummaryBallotPage] = validBmdSheet;
+
+    const result = await interpretSimplexBmdBallot(bmdSummaryBallotPage, {
+      electionDefinition:
+        electionPrimaryPrecinctSplitsFixtures.electionDefinition,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      testMode: true,
+      markThresholds: DEFAULT_MARK_THRESHOLDS,
+      adjudicationReasons: [
+        AdjudicationReason.BlankBallot,
+        AdjudicationReason.Undervote,
+      ],
+    });
+
+    assert(result[0].interpretation.type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+
+    expect(frontInterpretation.adjudicationInfo).toEqual({
+      requiresAdjudication: true,
+      enabledReasonInfos: [
+        {
+          contestId: 'county-leader-mammal',
+          expected: 1,
+          optionIds: [],
+          type: 'Undervote',
+        },
+      ],
+      enabledReasons: ['BlankBallot', 'Undervote'],
+      ignoredReasonInfos: [],
+    });
   });
 });
 


### PR DESCRIPTION
Curious to see what the wait time would be for a simple change with a good number of ripple effects.
- `libs/ballot-interpreter` has dependents in a few app packages - looks like this triggered builds and tests in:
  - //apps/central-scan/backend
  - //apps/central-scan/frontend
  - //apps/mark-scan/backend
  - //apps/mark-scan/frontend
  - //apps/scan/backend
  - //apps/scan/frontend

More than ideal, but expected, since the original packages are still intact and haven't been split up into smaller chunks.
The fact that full frontend builds get triggered is an unfortunate side-effect of having direct dependencies on the backend grout API code rather than just the types, but not sure I'd give up the cmd+click-to-definition convenience (although, the extra step of a `go to implementations` might not be that bad.

Copied from a recent change by hand, since I'm not sure how to deal with the whole upstream syncing deal at the moment, considering how different the fork is.