### PR TITLE
Run clippy and rustfmt checks when building Rust targets

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -28,3 +28,12 @@ common:ci --keep_going
 # Make sure we have as much info in the CI output as possible to debug failures.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 common:ci --verbose_failures
+
+# Enable rustfmt checks as part of the CI build.
+# Not currently enabled locally to ease dev iteration, assuming rustfmt is
+# enabled in the IDE.
+# TODO: Set up pre-commit hooks for linting/formatting.
+#
+# https://bazelbuild.github.io/rules_rust/rust_fmt.html#setup
+build:ci --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:ci --output_groups=+rustfmt_checks

--- a/.bazel/rust.bazelrc
+++ b/.bazel/rust.bazelrc
@@ -6,3 +6,11 @@ common --action_env=CARGO_PKG_HOMEPAGE="https://github.com/votingworks/vxsuite"
 common --action_env=CARGO_PKG_LICENSE="AGPL-3.0"
 common --action_env=CARGO_PKG_REPOSITORY="https://github.com/votingworks/vxsuite"
 common --action_env=RUSTDOC="None"
+
+# Enable clippy checks on all Rust targets.
+# See https://bazelbuild.github.io/rules_rust/rust_clippy.html#setup
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --@rules_rust//:clippy_flag="-Wclippy::pedantic"
+build --@rules_rust//:clippy_flag="-Wclippy::nursery"
+build --@rules_rust//:clippy_flag="-Wclippy::unwrap_used"
+build --output_groups=+clippy_checks


### PR DESCRIPTION
Add the `clippy` and `rustfmt` aspects to Rust builds -- waffled on whether or not to set up explicit test targets for better reporting, but the stdout output in CI looks useful enough, so taking the simpler route for now.