### PR TITLE
[CI] Add //libs/types/... to gh actions workflow, test cache restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             build_cache-v1-main-
 
       - name: Build and Test
-        run: bazel test //libs/basics/... --config=ci --test_tag_filters=-lint --disk_cache="/github/home/bazel_build_cache"
+        run: bazel test //libs/basics/... //libs/types/... --config=ci --test_tag_filters=-lint --disk_cache="/github/home/bazel_build_cache"
 
       - name: Save Build Cache
         uses: actions/cache/save@v4.1.1


### PR DESCRIPTION
Testing out the GH actions workflow from https://github.com/kofi-q/vxsweet/pull/28

Adding one more set of build targets in `//libs/types/...` to test out partial cache hits. Also generally curious about cache save/restore latency between GH and Circle.

So far (tiny sample size):
- Container setup takes roughly the same amount of time
- Checkout's definitely faster on GH, almost 2X - but also, `depth` is set to `1` on the GH workflow (I couldn't find a similar setting for Circle)
- Cache restore seems slightly faster on GH, at least for the smaller cache the GH workflow is using at the moment
- Cache save might be slower on GH - if the `43s` it took for `250MB` is anything to go by. Not sure if the machine size has an effect on that performance, though