### PR TITLE
[CI] Only save the build cache on successful runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,6 @@ commands:
                 - << pipeline.parameters.force_cache_save >>
           steps:
             - save_cache:
-                when: always
                 key: << parameters.key_prefix >>-v1-{{ .Branch }}-{{ .Revision }}-<< parameters.key_suffix >>
                 paths:
                   # NOTE: Keep in sync with .bazel/ci.bazelrc:


### PR DESCRIPTION
Noticed this can get into a state where consecutive failed and successful runs on the same commit leave the cache only partially formed with the cache save from the failed run (https://app.circleci.com/pipelines/github/kofi-q/vxsweet/72/workflows/2b805f2e-2427-4e0b-a100-a8e4920beb14/jobs/115)

Still optimistically saving the Playwright cache, which is either complete or absent.