### PR TITLE
If a Clippy warning falls in the CI woods...

### DIFF
--- a/.bazel/rust.bazelrc
+++ b/.bazel/rust.bazelrc
@@ -10,7 +10,8 @@ common --action_env=RUSTDOC="None"
 # Enable clippy checks on all Rust targets.
 # See https://bazelbuild.github.io/rules_rust/rust_clippy.html#setup
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build --@rules_rust//:clippy_flag="-Wclippy::pedantic"
-build --@rules_rust//:clippy_flag="-Wclippy::nursery"
-build --@rules_rust//:clippy_flag="-Wclippy::unwrap_used"
+build --@rules_rust//:clippy_flag="-Aclippy::pedantic"
+build --@rules_rust//:clippy_flag="-Aclippy::nursery"
+build --@rules_rust//:clippy_flag="-Aclippy::unwrap_used"
+build --@rules_rust//:clippy_flag="-Aclippy::result_large_err"
 build --output_groups=+clippy_checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
       - run:
           name: Build and Test
           command: |
-            bazel test //... --config=ci --test_tag_filters=-lint
+            bazel test //... --config=ci --test_tag_filters=-lint --build_tag_filters=-lint
 
   run_lint_checks:
     description: Lint all relevant source files in the build graph.

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -860,7 +860,7 @@ mod test {
     fn test_vertical_streaks() {
         let (mut side_a_image, side_b_image, options) =
             load_hmpb_fixture("general-election/letter", 1);
-        let thin_complete_streak_x = side_a_image.width() * 1 / 5;
+        let thin_complete_streak_x = side_a_image.width() / 5;
         let thick_complete_streak_x = side_a_image.width() * 2 / 5;
         let fuzzy_streak_x = side_a_image.width() * 3 / 5;
         let incomplete_streak_x = side_a_image.width() * 4 / 5;

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -43,7 +43,7 @@ impl Scanner {
             return Err(rusb::Error::NotFound.into());
         };
 
-        let mut device_handle = device.open()?;
+        let device_handle = device.open()?;
         device_handle.set_active_configuration(1)?;
         device_handle.claim_interface(0)?;
 


### PR DESCRIPTION
Fix a couple unaddressed Clippy warnings and downgrade the rest to `allow` to avoid the noise (could maybe restrict to CI only and leave them as warnings in local dev).

Also filtering out `lint_test` targets from the main build workflow, since they get built in the lint workflow.
