### PR TITLE
A few app backend test speedups...

### DIFF
--- a/apps/admin/backend/adjudication/adjudication.test.ts
+++ b/apps/admin/backend/adjudication/adjudication.test.ts
@@ -105,7 +105,7 @@ test('adjudicateVote', () => {
   expectVotes({ 'zoo-council-mammal': ['zebra'] });
 });
 
-test('adjudicateWriteIn', async () => {
+test('adjudicateWriteIn', () => {
   const store = Store.memoryStore();
   const logger = mockBaseLogger();
   const { electionDefinition } = electionTwoPartyPrimaryFixtures;
@@ -171,7 +171,7 @@ test('adjudicateWriteIn', async () => {
     status: 'pending',
   });
 
-  await adjudicateWriteIn({ writeInId, type: 'invalid' }, store, logger);
+  adjudicateWriteIn({ writeInId, type: 'invalid' }, store, logger);
   expectVotes({ 'zoo-council-mammal': [] });
   expectWriteInRecord({
     status: 'adjudicated',
@@ -182,7 +182,7 @@ test('adjudicateWriteIn', async () => {
     status: 'invalid',
   });
 
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     { writeInId, type: 'official-candidate', candidateId: 'lion' },
     store,
     logger
@@ -207,7 +207,7 @@ test('adjudicateWriteIn', async () => {
     contestId,
     name: 'Unofficial',
   });
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     { writeInId, type: 'write-in-candidate', candidateId: writeInCandidate.id },
     store,
     logger
@@ -228,7 +228,7 @@ test('adjudicateWriteIn', async () => {
     }
   );
 
-  await adjudicateWriteIn({ writeInId, type: 'invalid' }, store, logger);
+  adjudicateWriteIn({ writeInId, type: 'invalid' }, store, logger);
   expectVotes({ 'zoo-council-mammal': [] });
   expectWriteInRecord({
     status: 'adjudicated',
@@ -245,7 +245,7 @@ test('adjudicateWriteIn', async () => {
     }
   );
 
-  await adjudicateWriteIn({ writeInId, type: 'reset' }, store, logger);
+  adjudicateWriteIn({ writeInId, type: 'reset' }, store, logger);
   expectVotes({ 'zoo-council-mammal': ['write-in-0'] });
   expectWriteInRecord({
     status: 'pending',

--- a/apps/admin/backend/adjudication/adjudication.ts
+++ b/apps/admin/backend/adjudication/adjudication.ts
@@ -44,7 +44,7 @@ export function adjudicateVote(
   store.createVoteAdjudication(voteAdjudication);
 }
 
-async function logWriteInAdjudication({
+function logWriteInAdjudication({
   initialWriteInRecord,
   adjudicationAction,
   logger,
@@ -52,7 +52,7 @@ async function logWriteInAdjudication({
   initialWriteInRecord: WriteInRecord;
   adjudicationAction: WriteInAdjudicationAction;
   logger: BaseLogger;
-}): Promise<void> {
+}) {
   const { cvrId, contestId, optionId } = initialWriteInRecord;
 
   const formerStatusText = (() => {
@@ -90,7 +90,7 @@ async function logWriteInAdjudication({
   })();
 
   const message = `User adjudicated a write-in from ${formerStatusText} to ${newStatusText}.`;
-  await logger.log(LogEventId.WriteInAdjudicated, 'election_manager', {
+  void logger.log(LogEventId.WriteInAdjudicated, 'election_manager', {
     disposition: 'success',
     message,
     cvrId,
@@ -119,11 +119,11 @@ async function logWriteInAdjudication({
  * Adjudicates a write-in record for an official candidate, write-in candidate,
  * or marks it as invalid.
  */
-export async function adjudicateWriteIn(
+export function adjudicateWriteIn(
   adjudicationAction: WriteInAdjudicationAction,
   store: Store,
   logger: BaseLogger
-): Promise<void> {
+): void {
   const [initialWriteInRecord] = store.getWriteInRecords({
     electionId: assertDefined(store.getCurrentElectionId()),
     writeInId: adjudicationAction.writeInId,
@@ -187,7 +187,7 @@ export async function adjudicateWriteIn(
     );
   }
 
-  await logWriteInAdjudication({
+  logWriteInAdjudication({
     initialWriteInRecord,
     adjudicationAction,
     logger,

--- a/apps/admin/backend/app/app.auth.test.ts
+++ b/apps/admin/backend/app/app.auth.test.ts
@@ -32,11 +32,11 @@ beforeAll(() => {
 });
 
 test('getAuthStatus', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
   auth.getAuthStatus.mockClear(); // Clear mock calls from configureMachine
 
-  await apiClient.getAuthStatus();
+  await api.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {
     electionKey,
@@ -46,10 +46,10 @@ test('getAuthStatus', async () => {
 });
 
 test('checkPin', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  await apiClient.checkPin({ pin: '123456' });
+  await api.checkPin({ pin: '123456' });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
@@ -59,10 +59,10 @@ test('checkPin', async () => {
 });
 
 test('logOut', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  await apiClient.logOut();
+  await api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
     electionKey,
@@ -72,10 +72,10 @@ test('logOut', async () => {
 });
 
 test('updateSessionExpiry', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  await apiClient.updateSessionExpiry({
+  await api.updateSessionExpiry({
     sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
@@ -87,10 +87,10 @@ test('updateSessionExpiry', async () => {
 });
 
 test('programCard', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  void (await apiClient.programCard({ userRole: 'system_administrator' }));
+  void (await api.programCard({ userRole: 'system_administrator' }));
   expect(auth.programCard).toHaveBeenCalledTimes(1);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     1,
@@ -98,7 +98,7 @@ test('programCard', async () => {
     { userRole: 'system_administrator' }
   );
 
-  void (await apiClient.programCard({ userRole: 'election_manager' }));
+  void (await api.programCard({ userRole: 'election_manager' }));
   expect(auth.programCard).toHaveBeenCalledTimes(2);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     2,
@@ -106,7 +106,7 @@ test('programCard', async () => {
     { userRole: 'election_manager' }
   );
 
-  void (await apiClient.programCard({ userRole: 'poll_worker' }));
+  void (await api.programCard({ userRole: 'poll_worker' }));
   expect(auth.programCard).toHaveBeenCalledTimes(3);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     3,
@@ -116,10 +116,10 @@ test('programCard', async () => {
 });
 
 test('unprogramCard', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  void (await apiClient.unprogramCard());
+  void (await api.unprogramCard());
   expect(auth.unprogramCard).toHaveBeenCalledTimes(1);
   expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, {
     electionKey,
@@ -129,9 +129,9 @@ test('unprogramCard', async () => {
 });
 
 test('getAuthStatus before election definition has been configured', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
+  const { api, auth } = buildTestEnvironment();
 
-  await apiClient.getAuthStatus();
+  await api.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {
     jurisdiction,
@@ -140,9 +140,9 @@ test('getAuthStatus before election definition has been configured', async () =>
 });
 
 test('checkPin before election definition has been configured', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
+  const { api, auth } = buildTestEnvironment();
 
-  await apiClient.checkPin({ pin: '123456' });
+  await api.checkPin({ pin: '123456' });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
@@ -155,9 +155,9 @@ test('checkPin before election definition has been configured', async () => {
 });
 
 test('logOut before election definition has been configured', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
+  const { api, auth } = buildTestEnvironment();
 
-  await apiClient.logOut();
+  await api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
     jurisdiction,
@@ -166,9 +166,9 @@ test('logOut before election definition has been configured', async () => {
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
+  const { api, auth } = buildTestEnvironment();
 
-  await apiClient.updateSessionExpiry({
+  await api.updateSessionExpiry({
     sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);

--- a/apps/admin/backend/app/app.ballot_count_report_data.test.ts
+++ b/apps/admin/backend/app/app.ballot_count_report_data.test.ts
@@ -43,16 +43,16 @@ test('card counts', async () => {
     electionTwoPartyPrimaryFixtures;
   const { election } = electionDefinition;
 
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
+  const { api, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition);
   mockElectionManagerAuth(auth, electionDefinition.election);
 
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
+  const loadFileResult = await api.addCastVoteRecordFile({
     path: castVoteRecordExport.asDirectoryPath(),
   });
   loadFileResult.assertOk('load file failed');
 
-  await apiClient.setManualResults({
+  await api.setManualResults({
     precinctId: 'precinct-1',
     ballotStyleGroupId: '1M' as BallotStyleGroupId,
     votingMethod: 'precinct',
@@ -64,7 +64,7 @@ test('card counts', async () => {
   });
 
   expect(
-    await apiClient.getCardCounts({
+    api.getCardCounts({
       filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
       groupBy: {},
     })
@@ -77,7 +77,7 @@ test('card counts', async () => {
   ]);
 
   expect(
-    await apiClient.getCardCounts({
+    api.getCardCounts({
       filter: {},
       groupBy: { groupByPrecinct: true },
     })
@@ -97,7 +97,7 @@ test('card counts', async () => {
   ]);
 
   expect(
-    await apiClient.getCardCounts({
+    api.getCardCounts({
       filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
       groupBy: { groupByPrecinct: true },
     })

--- a/apps/admin/backend/app/app.ts
+++ b/apps/admin/backend/app/app.ts
@@ -152,7 +152,7 @@ function getCurrentElectionRecord(
   return electionRecord;
 }
 
-function buildApi({
+function buildApiInternal({
   auth,
   workspace,
   logger,
@@ -1105,7 +1105,17 @@ function buildApi({
 /**
  * A type to be used by the frontend to create a Grout API client
  */
-export type Api = ReturnType<typeof buildApi>;
+export type Api = ReturnType<typeof buildApiInternal>;
+
+export function buildApi(params: {
+  auth: DippedSmartCardAuthApi;
+  workspace: Workspace;
+  logger: Logger;
+  usbDrive: UsbDrive;
+  printer: Printer;
+}): Api {
+  return buildApiInternal(params);
+}
 
 /**
  * Builds an express application.

--- a/apps/admin/backend/app/app.ts
+++ b/apps/admin/backend/app/app.ts
@@ -253,13 +253,13 @@ function buildApi({
     async generateSignedHashValidationQrCodeValue() {
       const { codeVersion, machineId } = getMachineConfig();
       const electionRecord = getCurrentElectionRecord(workspace);
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
       const qrCodeValue = await generateSignedHashValidationQrCodeValue({
         electionRecord,
         machineId,
         softwareVersion: codeVersion,
       });
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
         disposition: 'success',
       });
       return qrCodeValue;
@@ -283,7 +283,7 @@ function buildApi({
     },
 
     async saveElectionPackageToUsb(): Promise<Result<void, ExportDataError>> {
-      await logger.logAsCurrentRole(LogEventId.SaveElectionPackageInit);
+      void logger.logAsCurrentRole(LogEventId.SaveElectionPackageInit);
       const exporter = buildExporter(usbDrive);
 
       const electionRecord = getCurrentElectionRecord(workspace);
@@ -341,7 +341,7 @@ function buildApi({
         await fs.rm(tempDirectory, { recursive: true });
       }
 
-      await logger.logAsCurrentRole(LogEventId.SaveElectionPackageComplete, {
+      void logger.logAsCurrentRole(LogEventId.SaveElectionPackageComplete, {
         disposition: 'success',
         message: 'Successfully saved election package.',
       });
@@ -444,7 +444,7 @@ function buildApi({
       })();
 
       if (electionPackageResult.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
           message: `Error configuring machine.`,
           disposition: 'failure',
           errorDetails: JSON.stringify(electionPackageResult.err()),
@@ -462,16 +462,16 @@ function buildApi({
         electionPackageHash,
       });
       store.setCurrentElectionId(electionId);
-      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         disposition: 'success',
         newBallotHash: electionDefinition.ballotHash,
       });
       return ok({ electionId });
     },
 
-    async unconfigure(): Promise<void> {
+    unconfigure(): void {
       store.deleteElection(loadCurrentElectionIdOrThrow(workspace));
-      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
       });
     },
@@ -488,13 +488,13 @@ function buildApi({
       return null;
     },
 
-    async markResultsOfficial(): Promise<void> {
+    markResultsOfficial(): void {
       store.setElectionResultsOfficial(
         loadCurrentElectionIdOrThrow(workspace),
         true
       );
 
-      await logger.logAsCurrentRole(LogEventId.MarkedTallyResultsOfficial, {
+      void logger.logAsCurrentRole(LogEventId.MarkedTallyResultsOfficial, {
         message:
           'User has marked the tally results as official, no more cast vote record files can be loaded.',
         disposition: 'success',
@@ -510,7 +510,7 @@ function buildApi({
         electionDefinition
       );
       if (listResult.isErr()) {
-        await logger.logAsCurrentRole(
+        void logger.logAsCurrentRole(
           LogEventId.ListCastVoteRecordExportsOnUsbDrive,
           {
             disposition: 'failure',
@@ -521,7 +521,7 @@ function buildApi({
         return [];
       }
       const castVoteRecordExportSummaries = listResult.ok();
-      await logger.logAsCurrentRole(
+      void logger.logAsCurrentRole(
         LogEventId.ListCastVoteRecordExportsOnUsbDrive,
         {
           disposition: 'success',
@@ -538,7 +538,7 @@ function buildApi({
     async addCastVoteRecordFile(input: {
       path: string;
     }): Promise<Result<CvrFileImportInfo, ImportCastVoteRecordsError>> {
-      await logger.logAsCurrentRole(LogEventId.ImportCastVoteRecordsInit, {
+      void logger.logAsCurrentRole(LogEventId.ImportCastVoteRecordsInit, {
         message: 'Importing cast vote records...',
       });
       const exportDirectoryPath =
@@ -552,15 +552,12 @@ function buildApi({
         exportDirectoryPath
       );
       if (importResult.isErr()) {
-        await logger.logAsCurrentRole(
-          LogEventId.ImportCastVoteRecordsComplete,
-          {
-            disposition: 'failure',
-            message: 'Error importing cast vote records.',
-            exportDirectoryPath,
-            errorDetails: JSON.stringify(importResult.err()),
-          }
-        );
+        void logger.logAsCurrentRole(LogEventId.ImportCastVoteRecordsComplete, {
+          disposition: 'failure',
+          message: 'Error importing cast vote records.',
+          exportDirectoryPath,
+          errorDetails: JSON.stringify(importResult.err()),
+        });
       } else {
         const { alreadyPresent: numAlreadyPresent, newlyAdded: numNewlyAdded } =
           importResult.ok();
@@ -568,20 +565,17 @@ function buildApi({
         if (numAlreadyPresent > 0) {
           message += ` Ignored ${numAlreadyPresent} duplicate(s).`;
         }
-        await logger.logAsCurrentRole(
-          LogEventId.ImportCastVoteRecordsComplete,
-          {
-            disposition: 'success',
-            message,
-            exportDirectoryPath,
-          }
-        );
+        void logger.logAsCurrentRole(LogEventId.ImportCastVoteRecordsComplete, {
+          disposition: 'success',
+          message,
+          exportDirectoryPath,
+        });
       }
       return importResult;
     },
 
-    async clearCastVoteRecordFiles(): Promise<void> {
-      await logger.logAsCurrentRole(
+    clearCastVoteRecordFiles(): void {
+      void logger.logAsCurrentRole(
         LogEventId.ClearImportedCastVoteRecordsInit,
         {
           message: 'Clearing imported cast vote records...',
@@ -590,7 +584,7 @@ function buildApi({
       const electionId = loadCurrentElectionIdOrThrow(workspace);
       store.deleteCastVoteRecordFiles(electionId);
       store.setElectionResultsOfficial(electionId, false);
-      await logger.logAsCurrentRole(
+      void logger.logAsCurrentRole(
         LogEventId.ClearImportedCastVoteRecordsComplete,
         {
           disposition: 'success',
@@ -625,8 +619,8 @@ function buildApi({
       );
     },
 
-    async adjudicateWriteIn(input: WriteInAdjudicationAction): Promise<void> {
-      await adjudicateWriteIn(input, store, logger);
+    adjudicateWriteIn(input: WriteInAdjudicationAction): void {
+      adjudicateWriteIn(input, store, logger);
     },
 
     getWriteInAdjudicationQueueMetadata(
@@ -680,22 +674,22 @@ function buildApi({
       });
     },
 
-    async deleteAllManualResults(): Promise<void> {
+    deleteAllManualResults(): void {
       store.deleteAllManualResults({
         electionId: loadCurrentElectionIdOrThrow(workspace),
       });
-      await logger.logAsCurrentRole(LogEventId.ManualTallyDataRemoved, {
+      void logger.logAsCurrentRole(LogEventId.ManualTallyDataRemoved, {
         message: 'User removed all manually entered tally data.',
         disposition: 'success',
       });
     },
 
-    async deleteManualResults(input: ManualResultsIdentifier): Promise<void> {
+    deleteManualResults(input: ManualResultsIdentifier): void {
       store.deleteManualResults({
         electionId: loadCurrentElectionIdOrThrow(workspace),
         ...input,
       });
-      await logger.logAsCurrentRole(LogEventId.ManualTallyDataRemoved, {
+      void logger.logAsCurrentRole(LogEventId.ManualTallyDataRemoved, {
         message:
           'User removed manually entered tally data for a particular ballot style, precinct, and voting method.',
         ...input,
@@ -718,7 +712,7 @@ function buildApi({
         votingMethod: input.votingMethod,
       });
 
-      await logger.logAsCurrentRole(LogEventId.ManualTallyDataEdited, {
+      void logger.logAsCurrentRole(LogEventId.ManualTallyDataEdited, {
         disposition: 'success',
         message:
           'User added or edited manually entered tally data for a particular ballot style, precinct, and voting method.',
@@ -802,7 +796,7 @@ function buildApi({
         );
 
       if (wrappedManualResults.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ParseError, {
+        void logger.logAsCurrentRole(LogEventId.ParseError, {
           message: 'Error converting ERR file to VX format',
           error: wrappedManualResults.err().message,
         });
@@ -820,7 +814,7 @@ function buildApi({
         votingMethod: input.votingMethod,
       });
 
-      await logger.logAsCurrentRole(
+      void logger.logAsCurrentRole(
         LogEventId.ElectionResultsReportingTallyFileImported,
         {
           disposition: 'success',
@@ -896,7 +890,7 @@ function buildApi({
         }),
       });
 
-      await logger.logAsCurrentRole(LogEventId.FileSaved, {
+      void logger.logAsCurrentRole(LogEventId.FileSaved, {
         disposition: exportFileResult.isOk() ? 'success' : 'failure',
         message: `${
           exportFileResult.isOk() ? 'Saved' : 'Failed to save'
@@ -948,7 +942,7 @@ function buildApi({
         ),
       });
 
-      await logger.logAsCurrentRole(LogEventId.FileSaved, {
+      void logger.logAsCurrentRole(LogEventId.FileSaved, {
         disposition: exportFileResult.isOk() ? 'success' : 'failure',
         message: `${
           exportFileResult.isOk() ? 'Saved' : 'Failed to save'
@@ -1024,7 +1018,7 @@ function buildApi({
         }),
       });
 
-      await logger.logAsCurrentRole(LogEventId.FileSaved, {
+      void logger.logAsCurrentRole(LogEventId.FileSaved, {
         disposition: exportFileResult.isOk() ? 'success' : 'failure',
         message: `${
           exportFileResult.isOk() ? 'Saved' : 'Failed to save'

--- a/apps/admin/backend/app/app.write_ins.test.ts
+++ b/apps/admin/backend/app/app.write_ins.test.ts
@@ -61,22 +61,22 @@ afterEach(() => {
 });
 
 test('getWriteInAdjudicationQueue', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: castVoteRecordExport.asDirectoryPath(),
     })
   ).unsafeUnwrap();
 
-  const allWriteIns = await apiClient.getWriteInAdjudicationQueue();
+  const allWriteIns = api.getWriteInAdjudicationQueue();
   expect(allWriteIns).toHaveLength(80);
 
   expect(
-    await apiClient.getWriteInAdjudicationQueue({
+    api.getWriteInAdjudicationQueue({
       contestId: 'Sheriff-4243fe0b',
     })
   ).toHaveLength(2);
@@ -92,24 +92,24 @@ test('getWriteInAdjudicationQueue', async () => {
     }
   );
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: secondReportPath,
     })
   ).unsafeUnwrap();
 
-  const allWriteInsDouble = await apiClient.getWriteInAdjudicationQueue();
+  const allWriteInsDouble = api.getWriteInAdjudicationQueue();
   expect(allWriteInsDouble).toHaveLength(160);
   expect(allWriteInsDouble.slice(0, 80)).toEqual(allWriteIns);
 });
 
 test('getWriteInAdjudicationQueueMetadata', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: castVoteRecordExport.asDirectoryPath(),
     })
   ).unsafeUnwrap();
@@ -118,8 +118,7 @@ test('getWriteInAdjudicationQueueMetadata', async () => {
     (contest) => contest.type === 'candidate' && contest.allowWriteIns
   );
 
-  const allQueueMetadata =
-    await apiClient.getWriteInAdjudicationQueueMetadata();
+  const allQueueMetadata = api.getWriteInAdjudicationQueueMetadata();
   expect(allQueueMetadata).toHaveLength(contestsWithWriteIns.length);
   assert(
     allQueueMetadata.every(
@@ -128,7 +127,7 @@ test('getWriteInAdjudicationQueueMetadata', async () => {
   );
 
   expect(
-    await apiClient.getWriteInAdjudicationQueueMetadata({
+    api.getWriteInAdjudicationQueueMetadata({
       contestId: 'Sheriff-4243fe0b',
     })
   ).toEqual([
@@ -141,21 +140,21 @@ test('getWriteInAdjudicationQueueMetadata', async () => {
 });
 
 test('getWriteInAdjudicationContext', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, manualCastVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   const reportDirectoryPath = manualCastVoteRecordExport.asDirectoryPath();
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: reportDirectoryPath,
     })
   ).unsafeUnwrap();
 
   // look at a contest that can have multiple write-ins per ballot
   const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
-  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
+  const writeInIds = api.getWriteInAdjudicationQueue({
     contestId,
   });
   expect(writeInIds).toHaveLength(2);
@@ -164,15 +163,14 @@ test('getWriteInAdjudicationContext', async () => {
   assert(writeInIdA !== undefined && writeInIdB !== undefined);
 
   // check image of first write-in
-  const writeInImageViewA = await apiClient.getWriteInImageView({
+  const writeInImageViewA = await api.getWriteInImageView({
     writeInId: writeInIdA,
   });
   assert(writeInImageViewA);
 
-  const writeInAdjudicationContextA =
-    await apiClient.getWriteInAdjudicationContext({
-      writeInId: writeInIdA,
-    });
+  const writeInAdjudicationContextA = api.getWriteInAdjudicationContext({
+    writeInId: writeInIdA,
+  });
   assert(writeInAdjudicationContextA);
 
   expect(writeInAdjudicationContextA).toMatchObject(
@@ -191,17 +189,16 @@ test('getWriteInAdjudicationContext', async () => {
   );
 
   // adjudicate first write-in for an official candidate
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     writeInId: writeInIdA,
     type: 'official-candidate',
     candidateId: 'Mary-Baker-Eddy-350785d5',
   });
 
   // check the second write-in detail view, which should show the just-adjudicated write-in
-  const writeInAdjudicationContextB1 =
-    await apiClient.getWriteInAdjudicationContext({
-      writeInId: writeInIdB,
-    });
+  const writeInAdjudicationContextB1 = api.getWriteInAdjudicationContext({
+    writeInId: writeInIdB,
+  });
 
   expect(writeInAdjudicationContextB1).toMatchObject(
     typedAs<Partial<WriteInAdjudicationContext>>({
@@ -221,19 +218,18 @@ test('getWriteInAdjudicationContext', async () => {
   );
 
   // re-adjudicate the first write-in for a write-in candidate and expect the ids to change
-  const { id: writeInCandidateId } = await apiClient.addWriteInCandidate({
+  const { id: writeInCandidateId } = api.addWriteInCandidate({
     contestId,
     name: 'Bob Hope',
   });
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     writeInId: writeInIdA,
     type: 'write-in-candidate',
     candidateId: writeInCandidateId,
   });
-  const writeInAdjudicationContextB2 =
-    await apiClient.getWriteInAdjudicationContext({
-      writeInId: writeInIdB,
-    });
+  const writeInAdjudicationContextB2 = api.getWriteInAdjudicationContext({
+    writeInId: writeInIdB,
+  });
 
   expect(writeInAdjudicationContextB2).toMatchObject(
     typedAs<Partial<WriteInAdjudicationContext>>({
@@ -254,21 +250,21 @@ test('getWriteInAdjudicationContext', async () => {
 });
 
 test('getWriteInImageView on hmpb', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, manualCastVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   const reportDirectoryPath = manualCastVoteRecordExport.asDirectoryPath();
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: reportDirectoryPath,
     })
   ).unsafeUnwrap();
 
   // look at a contest that can have multiple write-ins per ballot
   const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
-  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
+  const writeInIds = api.getWriteInAdjudicationQueue({
     contestId,
   });
   expect(writeInIds).toHaveLength(2);
@@ -277,7 +273,7 @@ test('getWriteInImageView on hmpb', async () => {
   assert(writeInIdA !== undefined && writeInIdB !== undefined);
 
   // check image of first write-in
-  const writeInImageViewA = await apiClient.getWriteInImageView({
+  const writeInImageViewA = await api.getWriteInImageView({
     writeInId: writeInIdA,
   });
   assert(writeInImageViewA);
@@ -324,7 +320,7 @@ test('getWriteInImageView on hmpb', async () => {
 
   // check the second write-in image view, which should have the same image
   // but different writeInCoordinates
-  const writeInImageViewB1 = await apiClient.getWriteInImageView({
+  const writeInImageViewB1 = await api.getWriteInImageView({
     writeInId: writeInIdB,
   });
 
@@ -347,21 +343,21 @@ test('getWriteInImageView on hmpb', async () => {
 });
 
 test('getWriteInImageView on bmd', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionTwoPartyPrimaryFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   const reportDirectoryPath = castVoteRecordExport.asDirectoryPath();
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: reportDirectoryPath,
     })
   ).unsafeUnwrap();
 
   // look at a contest that can have multiple write-ins per ballot
   const contestId = 'zoo-council-mammal';
-  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
+  const writeInIds = api.getWriteInAdjudicationQueue({
     contestId,
   });
   expect(writeInIds).toHaveLength(24);
@@ -369,7 +365,7 @@ test('getWriteInImageView on bmd', async () => {
   assert(writeInIdA !== undefined && writeInIdB !== undefined);
 
   // check image of first write-in
-  const writeInImageViewA = await apiClient.getWriteInImageView({
+  const writeInImageViewA = await api.getWriteInImageView({
     writeInId: writeInIdA,
   });
   assert(writeInImageViewA);
@@ -381,7 +377,7 @@ test('getWriteInImageView on bmd', async () => {
 
   // check the second write-in image view, which should have the same image
   // but different writeInCoordinates
-  const writeInImageViewB1 = await apiClient.getWriteInImageView({
+  const writeInImageViewB1 = await api.getWriteInImageView({
     writeInId: writeInIdB,
   });
 
@@ -391,61 +387,53 @@ test('getWriteInImageView on bmd', async () => {
 });
 
 test('getFirstPendingWriteInId', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
 
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: castVoteRecordExport.asDirectoryPath(),
     })
   ).unsafeUnwrap();
 
   const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
 
-  const writeInQueue = await apiClient.getWriteInAdjudicationQueue({
+  const writeInQueue = api.getWriteInAdjudicationQueue({
     contestId,
   });
 
   function adjudicateAtIndex(index: number) {
-    return apiClient.adjudicateWriteIn({
+    return api.adjudicateWriteIn({
       writeInId: writeInQueue[index]!,
       type: 'invalid',
     });
   }
 
-  expect(await apiClient.getFirstPendingWriteInId({ contestId })).toEqual(
-    writeInQueue[0]
-  );
+  expect(api.getFirstPendingWriteInId({ contestId })).toEqual(writeInQueue[0]);
 
-  await adjudicateAtIndex(0);
-  expect(await apiClient.getFirstPendingWriteInId({ contestId })).toEqual(
-    writeInQueue[1]
-  );
+  adjudicateAtIndex(0);
+  expect(api.getFirstPendingWriteInId({ contestId })).toEqual(writeInQueue[1]);
 
-  await adjudicateAtIndex(2);
-  expect(await apiClient.getFirstPendingWriteInId({ contestId })).toEqual(
-    writeInQueue[1]
-  );
+  adjudicateAtIndex(2);
+  expect(api.getFirstPendingWriteInId({ contestId })).toEqual(writeInQueue[1]);
 
-  await adjudicateAtIndex(1);
-  expect(await apiClient.getFirstPendingWriteInId({ contestId })).toEqual(
-    writeInQueue[3]
-  );
+  adjudicateAtIndex(1);
+  expect(api.getFirstPendingWriteInId({ contestId })).toEqual(writeInQueue[3]);
 
   for (const [i] of writeInQueue.entries()) {
-    await adjudicateAtIndex(i);
+    adjudicateAtIndex(i);
   }
-  expect(await apiClient.getFirstPendingWriteInId({ contestId })).toEqual(null);
+  expect(api.getFirstPendingWriteInId({ contestId })).toEqual(null);
 });
 
 test('handling unmarked write-ins', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
+  const { api, auth } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
   const { election } = electionDefinition;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
   mockElectionManagerAuth(auth, electionDefinition.election);
 
   // modify the write-ins for a contest to be unmarked write-ins
@@ -483,18 +471,18 @@ test('handling unmarked write-ins', async () => {
     }
   );
 
-  const addTestFileResult = await apiClient.addCastVoteRecordFile({
+  const addTestFileResult = await api.addCastVoteRecordFile({
     path: exportDirectoryPath,
   });
   assert(addTestFileResult.isOk());
 
-  const [writeInId] = await apiClient.getWriteInAdjudicationQueue({
+  const [writeInId] = api.getWriteInAdjudicationQueue({
     contestId: WRITE_IN_CONTEST_ID,
   });
   assert(writeInId !== undefined);
 
   // check that the unmarked status appears in the write-in adjudication context
-  const writeInContext = await apiClient.getWriteInAdjudicationContext({
+  const writeInContext = api.getWriteInAdjudicationContext({
     writeInId,
   });
   expect(writeInContext.writeIn.isUnmarked).toEqual(true);
@@ -512,23 +500,24 @@ test('handling unmarked write-ins', async () => {
       includeGenericWriteIn: false,
     });
     expect(
-      (await apiClient.getResultsForTallyReports())[0]?.scannedResults
-        .contestResults[WRITE_IN_CONTEST_ID]
+      (await api.getResultsForTallyReports())[0]?.scannedResults.contestResults[
+        WRITE_IN_CONTEST_ID
+      ]
     ).toEqual(expectedResults.contestResults[WRITE_IN_CONTEST_ID]);
   }
 
-  async function expectWriteInSummary(
+  function expectWriteInSummary(
     summary: Partial<Tabulation.ContestWriteInSummary>
-  ): Promise<void> {
+  ) {
     expect(
-      (await apiClient.getElectionWriteInSummary()).contestWriteInSummaries[
+      api.getElectionWriteInSummary().contestWriteInSummaries[
         WRITE_IN_CONTEST_ID
       ]
     ).toMatchObject(summary);
   }
 
   // UWIs should appear in the write-in summary, but not in the tally results
-  await expectWriteInSummary({
+  expectWriteInSummary({
     pendingTally: 2,
     invalidTally: 0,
     totalTally: 2,
@@ -546,12 +535,12 @@ test('handling unmarked write-ins', async () => {
   });
 
   // a UWI should be reflected in tallies if we mark it as valid
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     writeInId,
     type: 'official-candidate',
     candidateId: OFFICIAL_CANDIDATE_ID,
   });
-  await expectWriteInSummary({
+  expectWriteInSummary({
     pendingTally: 1,
     invalidTally: 0,
     totalTally: 2,
@@ -576,11 +565,11 @@ test('handling unmarked write-ins', async () => {
   });
 
   // an invalid UWI should appear the same as unadjudicated in tallies
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     writeInId,
     type: 'invalid',
   });
-  await expectWriteInSummary({
+  expectWriteInSummary({
     pendingTally: 1,
     invalidTally: 1,
     totalTally: 2,
@@ -599,20 +588,20 @@ test('handling unmarked write-ins', async () => {
 });
 
 test('adjudicating write-ins changes their status and is reflected in tallies', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
+  const { auth, api } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
   const { election } = electionDefinition;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(api, auth, electionDefinition);
   (
-    await apiClient.addCastVoteRecordFile({
+    await api.addCastVoteRecordFile({
       path: castVoteRecordExport.asDirectoryPath(),
     })
   ).unsafeUnwrap();
 
   // look at a contest that can have multiple write-ins per ballot
   const contestId = 'Governor-061a401b';
-  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
+  const writeInIds = api.getWriteInAdjudicationQueue({
     contestId,
   });
   expect(writeInIds).toHaveLength(2);
@@ -631,37 +620,27 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       includeGenericWriteIn: false,
     });
     expect(
-      (await apiClient.getResultsForTallyReports())[0]?.scannedResults
-        .contestResults[contestId]
+      (await api.getResultsForTallyReports())[0]?.scannedResults.contestResults[
+        contestId
+      ]
     ).toEqual(expectedResults.contestResults[contestId]);
   }
 
-  async function expectWriteInSummary(
-    summary: Tabulation.ContestWriteInSummary
-  ): Promise<void> {
+  function expectWriteInSummary(summary: Tabulation.ContestWriteInSummary) {
     expect(
-      (await apiClient.getElectionWriteInSummary()).contestWriteInSummaries[
-        contestId
-      ]
+      api.getElectionWriteInSummary().contestWriteInSummaries[contestId]
     ).toEqual(summary);
   }
 
-  async function expectWriteInRecord(
-    id: Id,
-    expected: Partial<WriteInRecord>
-  ): Promise<void> {
+  function expectWriteInRecord(id: Id, expected: Partial<WriteInRecord>) {
     expect(
-      (await apiClient.getWriteInAdjudicationContext({ writeInId: id })).writeIn
+      api.getWriteInAdjudicationContext({ writeInId: id }).writeIn
     ).toMatchObject(expected);
   }
 
   // unadjudicated results
-  await expectWriteInRecord(writeInId, {
-    status: 'pending',
-  });
-  expect(
-    await apiClient.getWriteInAdjudicationQueueMetadata({ contestId })
-  ).toEqual([
+  expectWriteInRecord(writeInId, { status: 'pending' });
+  expect(api.getWriteInAdjudicationQueueMetadata({ contestId })).toEqual([
     {
       contestId,
       pendingTally: 2,
@@ -685,7 +664,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       },
     },
   });
-  await expectWriteInSummary({
+  expectWriteInSummary({
     candidateTallies: {},
     contestId: 'Governor-061a401b',
     invalidTally: 0,
@@ -694,11 +673,11 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // check invalid
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     type: 'invalid',
     writeInId,
   });
-  await expectWriteInRecord(writeInId, {
+  expectWriteInRecord(writeInId, {
     adjudicationType: 'invalid',
     status: 'adjudicated',
   });
@@ -720,9 +699,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
     },
   });
   expect(
-    (await apiClient.getElectionWriteInSummary()).contestWriteInSummaries[
-      contestId
-    ]
+    api.getElectionWriteInSummary().contestWriteInSummaries[contestId]
   ).toEqual({
     candidateTallies: {},
     contestId: 'Governor-061a401b',
@@ -732,12 +709,12 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // check official candidate
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     type: 'official-candidate',
     candidateId: 'Hannah-Dustin-ab4ef7c8',
     writeInId,
   });
-  await expectWriteInRecord(writeInId, {
+  expectWriteInRecord(writeInId, {
     adjudicationType: 'official-candidate',
     candidateId: 'Hannah-Dustin-ab4ef7c8',
     status: 'adjudicated',
@@ -759,7 +736,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       },
     },
   });
-  await expectWriteInSummary({
+  expectWriteInSummary({
     contestId: 'Governor-061a401b',
     invalidTally: 0,
     pendingTally: 1,
@@ -775,16 +752,16 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // check unofficial candidate
-  const writeInCandidate = await apiClient.addWriteInCandidate({
+  const writeInCandidate = api.addWriteInCandidate({
     contestId,
     name: 'Mr. Hero',
   });
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     type: 'write-in-candidate',
     candidateId: writeInCandidate.id,
     writeInId,
   });
-  await expectWriteInRecord(writeInId, {
+  expectWriteInRecord(writeInId, {
     adjudicationType: 'write-in-candidate',
     candidateId: writeInCandidate.id,
     status: 'adjudicated',
@@ -810,7 +787,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       },
     },
   });
-  await expectWriteInSummary({
+  expectWriteInSummary({
     contestId: 'Governor-061a401b',
     invalidTally: 0,
     pendingTally: 1,
@@ -826,11 +803,11 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // circle back to invalid
-  await apiClient.adjudicateWriteIn({
+  api.adjudicateWriteIn({
     type: 'invalid',
     writeInId,
   });
-  await expectWriteInRecord(writeInId, {
+  expectWriteInRecord(writeInId, {
     adjudicationType: 'invalid',
     status: 'adjudicated',
   });
@@ -852,9 +829,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
     },
   });
   expect(
-    (await apiClient.getElectionWriteInSummary()).contestWriteInSummaries[
-      contestId
-    ]
+    api.getElectionWriteInSummary().contestWriteInSummaries[contestId]
   ).toEqual({
     candidateTallies: {},
     contestId: 'Governor-061a401b',
@@ -864,12 +839,10 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // write-in candidate should be deleted as they are no longer referenced
-  expect(await apiClient.getWriteInCandidates({ contestId })).toEqual([]);
+  expect(api.getWriteInCandidates({ contestId })).toEqual([]);
 
   // adjudication queue metadata should be updated
-  expect(
-    await apiClient.getWriteInAdjudicationQueueMetadata({ contestId })
-  ).toEqual([
+  expect(api.getWriteInAdjudicationQueueMetadata({ contestId })).toEqual([
     {
       contestId,
       pendingTally: 1,

--- a/apps/admin/backend/perf/load_cvrs.test.ts
+++ b/apps/admin/backend/perf/load_cvrs.test.ts
@@ -20,8 +20,8 @@ const RECORDS_PER_REPORT = 10000;
 
 test('loading CVR file performance', async () => {
   const timer = getPerformanceTimer();
-  const { apiClient, workspace, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
+  const { api, workspace, auth } = buildTestEnvironment();
+  await configureMachine(api, auth, electionDefinition);
   mockElectionManagerAuth(auth, electionDefinition.election);
   timer.checkpoint(`test setup complete`);
 
@@ -32,7 +32,7 @@ test('loading CVR file performance', async () => {
       RECORDS_PER_REPORT.toString(),
       i.toString()
     );
-    const addReportResult = await apiClient.addCastVoteRecordFile({
+    const addReportResult = await api.addCastVoteRecordFile({
       path: reportDirectoryPath,
     });
     assert(addReportResult.isOk());

--- a/apps/admin/backend/perf/tally_cvrs.test.ts
+++ b/apps/admin/backend/perf/tally_cvrs.test.ts
@@ -9,11 +9,9 @@ const electionDefinition = electionTwoPartyPrimaryDefinition;
 
 test.skip('tally performance', async () => {
   const timer = getPerformanceTimer();
-  const { apiClient, auth } = buildTestEnvironment(
-    getBackupPath('performance')
-  );
+  const { api, auth } = buildTestEnvironment(getBackupPath('performance'));
   mockElectionManagerAuth(auth, electionDefinition.election);
   timer.checkpoint(`test setup complete`);
-  await apiClient.getResultsForTallyReports();
+  await api.getResultsForTallyReports();
   timer.end();
 });

--- a/apps/admin/backend/reports/ballot_count_report.ts
+++ b/apps/admin/backend/reports/ballot_count_report.ts
@@ -109,7 +109,7 @@ export async function generateBallotCountReportPreview({
       warning: pdf.isErr() ? { type: pdf.err() } : warning,
     };
   })();
-  await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
+  void logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed a ballot count report.${
       result.warning ? ` Warning: ${result.warning.type}` : ''
     }`,
@@ -137,13 +137,13 @@ export async function printBallotCountReport({
     // so rendering the PDF shouldn't error
     const data = (await renderToPdf({ document: report })).unsafeUnwrap();
     await printer.print({ data });
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `User printed a ballot count report.`,
       disposition: 'success',
     });
   } catch (error) {
     assert(error instanceof Error);
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `Error in attempting to print ballot count report: ${error.message}`,
       disposition: 'failure',
     });
@@ -168,7 +168,7 @@ export async function exportBallotCountReportPdf({
   const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exportFileResult = await exportFile({ path, data });
 
-  await logger.logAsCurrentRole(LogEventId.FileSaved, {
+  void logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: exportFileResult.isOk() ? 'success' : 'failure',
     message: `${
       exportFileResult.isOk() ? 'Saved' : 'Failed to save'

--- a/apps/admin/backend/reports/readiness.ts
+++ b/apps/admin/backend/reports/readiness.ts
@@ -76,12 +76,12 @@ export async function saveReadinessReport({
   );
 
   if (exportFileResult.isOk()) {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `User saved the equipment readiness report to a USB drive.`,
       disposition: 'success',
     });
   } else {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `Error while attempting to save the equipment readiness report to a USB drive: ${
         exportFileResult.err().message
       }`,

--- a/apps/admin/backend/reports/tally_report.ts
+++ b/apps/admin/backend/reports/tally_report.ts
@@ -135,7 +135,7 @@ export async function generateTallyReportPreview({
       warning: pdfResult.isErr() ? { type: pdfResult.err() } : warning,
     };
   })();
-  await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
+  void logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed a tally report.${
       result.warning ? ` Warning: ${result.warning.type}` : ''
     }`,
@@ -163,13 +163,13 @@ export async function printTallyReport({
     // so rendering the PDF shouldn't error
     const data = (await renderToPdf({ document: report })).unsafeUnwrap();
     await printer.print({ data });
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `User printed a tally report.`,
       disposition: 'success',
     });
   } catch (error) {
     assert(error instanceof Error);
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `Error in attempting to print tally report: ${error.message}`,
       disposition: 'failure',
     });
@@ -194,7 +194,7 @@ export async function exportTallyReportPdf({
   const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exportFileResult = await exportFile({ path, data });
 
-  await logger.logAsCurrentRole(LogEventId.FileSaved, {
+  void logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: exportFileResult.isOk() ? 'success' : 'failure',
     message: `${
       exportFileResult.isOk() ? 'Saved' : 'Failed to save'

--- a/apps/admin/backend/reports/test_print.ts
+++ b/apps/admin/backend/reports/test_print.ts
@@ -88,13 +88,13 @@ export async function printTestPage({
     // The test print shouldn't hit the PDF size limit
     const data = (await renderToPdf({ document: report })).unsafeUnwrap();
     await printer.print({ data });
-    await logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
+    void logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
       message: `User started a print diagnostic by printing a test page.`,
       disposition: 'success',
     });
   } catch (error) {
     assert(error instanceof Error);
-    await logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
+    void logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
       message: `Error attempting to send test page to the printer: ${error.message}`,
       disposition: 'failure',
     });

--- a/apps/admin/backend/reports/write_in_adjudication_report.ts
+++ b/apps/admin/backend/reports/write_in_adjudication_report.ts
@@ -69,7 +69,7 @@ export async function generateWriteInAdjudicationReportPreview({
       warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
     };
   })();
-  await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
+  void logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed the write-in adjudication report.${
       result.warning ? ` Warning: ${result.warning.type}` : ''
     }`,
@@ -97,13 +97,13 @@ export async function printWriteInAdjudicationReport({
     // so rendering the PDF shouldn't error
     const data = (await renderToPdf({ document: report })).unsafeUnwrap();
     await printer.print({ data });
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `User printed the write-in adjudication report.`,
       disposition: 'success',
     });
   } catch (error) {
     assert(error instanceof Error);
-    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+    void logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
       message: `Error in attempting to print the write-in adjudication report: ${error.message}`,
       disposition: 'failure',
     });
@@ -128,7 +128,7 @@ export async function exportWriteInAdjudicationReportPdf({
   const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exportFileResult = await exportFile({ path, data });
 
-  await logger.logAsCurrentRole(LogEventId.FileSaved, {
+  void logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: exportFileResult.isOk() ? 'success' : 'failure',
     message: `${
       exportFileResult.isOk() ? 'Saved' : 'Failed to save'

--- a/apps/admin/backend/tabulation/election_results_reporting.ts
+++ b/apps/admin/backend/tabulation/election_results_reporting.ts
@@ -27,7 +27,7 @@ export async function parseElectionResultsReportingFile(
   });
 
   if (readFileResult.isErr()) {
-    await logger.logAsCurrentRole(LogEventId.FileReadError, {
+    void logger.logAsCurrentRole(LogEventId.FileReadError, {
       message: `An error occurred when reading ERR file: ${JSON.stringify(
         readFileResult.err()
       )}`,

--- a/apps/admin/backend/tabulation/full_results.test.ts
+++ b/apps/admin/backend/tabulation/full_results.test.ts
@@ -377,7 +377,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     contestId: candidateContestId,
   });
   const [writeIn1, writeIn2, writeIn3, writeIn4, writeIn5, writeIn6] = writeIns;
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn1!.id,
       type: 'invalid',
@@ -385,7 +385,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     store,
     logger
   );
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn2!.id,
       type: 'invalid',
@@ -393,7 +393,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     store,
     logger
   );
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn3!.id,
       type: 'official-candidate',
@@ -402,7 +402,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     store,
     logger
   );
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn4!.id,
       type: 'official-candidate',
@@ -416,7 +416,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     contestId: candidateContestId,
     name: 'Mr. Pickles',
   });
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn5!.id,
       type: 'write-in-candidate',
@@ -430,7 +430,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     contestId: candidateContestId,
     name: 'Ms. Tomato',
   });
-  await adjudicateWriteIn(
+  adjudicateWriteIn(
     {
       writeInId: writeIn6!.id,
       type: 'write-in-candidate',
@@ -732,7 +732,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   });
   expect(writeIns.length).toEqual(56);
   for (const writeIn of writeIns) {
-    await adjudicateWriteIn(
+    adjudicateWriteIn(
       {
         writeInId: writeIn.id,
         type: 'invalid',

--- a/apps/admin/backend/workspace/workspace.ts
+++ b/apps/admin/backend/workspace/workspace.ts
@@ -6,6 +6,7 @@ import {
 } from '@vx/libs/backend/diagnostics';
 import { BaseLogger } from '@vx/libs/logging/src';
 import { Store } from '../store/store';
+import { isIntegrationTest } from '@vx/libs/utils/src';
 
 /**
  * Options for defining a Workspace.
@@ -24,7 +25,10 @@ export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'data.db');
-  const store = Store.fileStore(dbPath, logger);
+  const store =
+    process.env.NODE_ENV === 'test' || isIntegrationTest()
+      ? Store.memoryStore()
+      : Store.fileStore(dbPath, logger);
 
   // check disk space on summary to detect a new maximum available disk space
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(

--- a/apps/central-scan/backend/app/app.ts
+++ b/apps/central-scan/backend/app/app.ts
@@ -56,7 +56,7 @@ export interface AppOptions {
   usbDrive: UsbDrive;
 }
 
-function buildApi({
+function buildApiInternal({
   auth,
   workspace,
   logger,
@@ -211,7 +211,7 @@ function buildApi({
       }
     },
 
-    async continueScanning(input: { forceAccept: boolean }): Promise<void> {
+    continueScanning(input: { forceAccept: boolean }): void {
       try {
         const { forceAccept } = input;
         importer.continueImport(input);
@@ -327,7 +327,13 @@ function buildApi({
 /**
  * A type to be used by the frontend to create a Grout API client
  */
-export type Api = ReturnType<typeof buildApi>;
+export type Api = ReturnType<typeof buildApiInternal>;
+
+export function buildApi(
+  params: Exclude<AppOptions, 'allowedExportPatterns'>
+): Api {
+  return buildApiInternal(params);
+}
 
 /**
  * Builds an express application, using `store` and `importer` to do the heavy

--- a/apps/central-scan/backend/app/app.ts
+++ b/apps/central-scan/backend/app/app.ts
@@ -97,11 +97,11 @@ function buildApi({
 
     async setTestMode(input: { testMode: boolean }) {
       const { testMode } = input;
-      await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
+      void logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling to ${testMode ? 'Test' : 'Official'} Ballot Mode...`,
       });
       await importer.setTestMode(testMode);
-      await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
+      void logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
         disposition: 'success',
         message: `Successfully toggled to ${
           testMode ? 'Test' : 'Official'
@@ -121,7 +121,7 @@ function buildApi({
         .getBatches()
         .find((batch) => batch.id === batchId)?.count;
 
-      await logger.logAsCurrentRole(LogEventId.DeleteScanBatchInit, {
+      void logger.logAsCurrentRole(LogEventId.DeleteScanBatchInit, {
         message: `User deleting batch id ${batchId}...`,
         numberOfBallotsInBatch,
         batchId,
@@ -129,7 +129,7 @@ function buildApi({
 
       try {
         workspace.store.deleteBatch(batchId);
-        await logger.logAsCurrentRole(LogEventId.DeleteScanBatchComplete, {
+        void logger.logAsCurrentRole(LogEventId.DeleteScanBatchComplete, {
           disposition: 'success',
           message: `User successfully deleted batch id: ${batchId} containing ${numberOfBallotsInBatch} ballots.`,
           numberOfBallotsInBatch,
@@ -160,7 +160,7 @@ function buildApi({
         logger
       );
       if (electionPackageResult.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
           message: `Error configuring machine.`,
           disposition: 'failure',
           errorDetails: JSON.stringify(electionPackageResult.err()),
@@ -180,7 +180,7 @@ function buildApi({
       );
       store.setSystemSettings(systemSettings);
 
-      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',
         ballotHash: electionDefinition.ballotHash,
@@ -204,10 +204,10 @@ function buildApi({
     async scanBatch(): Promise<void> {
       try {
         const batchId = await importer.startImport();
-        await logBatchStartSuccess(logger, batchId);
+        void logBatchStartSuccess(logger, batchId);
       } catch (error) {
         assert(error instanceof Error);
-        await logBatchStartFailure(logger, error);
+        void logBatchStartFailure(logger, error);
       }
     },
 
@@ -215,10 +215,10 @@ function buildApi({
       try {
         const { forceAccept } = input;
         importer.continueImport(input);
-        await logScanBatchContinueSuccess(logger, forceAccept);
+        void logScanBatchContinueSuccess(logger, forceAccept);
       } catch (error) {
         assert(error instanceof Error);
-        await logScanBatchContinueFailure(logger, error);
+        void logScanBatchContinueFailure(logger, error);
       }
     },
 
@@ -231,7 +231,7 @@ function buildApi({
       assert(store.getCanUnconfigure() || input.ignoreBackupRequirement);
 
       await importer.unconfigure();
-      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
           'User successfully unconfigured the machine to remove the current election and all current ballot data.',
@@ -249,7 +249,7 @@ function buildApi({
       isMinimalExport?: boolean;
     }): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
       const logItem = input.isMinimalExport ? 'cast vote records' : 'backup';
-      await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
+      void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
         message: `Exporting ${logItem}...`,
       });
       const exportResult = await exportCastVoteRecordsToUsbDrive(
@@ -264,22 +264,16 @@ function buildApi({
         store.setScannerBackedUp();
       }
       if (exportResult.isErr()) {
-        await logger.logAsCurrentRole(
-          LogEventId.ExportCastVoteRecordsComplete,
-          {
-            disposition: 'failure',
-            message: `Error exporting ${logItem}.`,
-            errorDetails: JSON.stringify(exportResult.err()),
-          }
-        );
+        void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
+          disposition: 'failure',
+          message: `Error exporting ${logItem}.`,
+          errorDetails: JSON.stringify(exportResult.err()),
+        });
       } else {
-        await logger.logAsCurrentRole(
-          LogEventId.ExportCastVoteRecordsComplete,
-          {
-            disposition: 'success',
-            message: `Successfully exported ${logItem}.`,
-          }
-        );
+        void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
+          disposition: 'success',
+          message: `Successfully exported ${logItem}.`,
+        });
       }
       return exportResult;
     },
@@ -309,13 +303,13 @@ function buildApi({
     async generateSignedHashValidationQrCodeValue() {
       const { codeVersion, machineId } = getMachineConfig();
       const electionRecord = store.getElectionRecord();
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
       const qrCodeValue = await generateSignedHashValidationQrCodeValue({
         electionRecord,
         machineId,
         softwareVersion: codeVersion,
       });
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
         disposition: 'success',
       });
       return qrCodeValue;

--- a/apps/central-scan/backend/diagnostic/diagnostic.ts
+++ b/apps/central-scan/backend/diagnostic/diagnostic.ts
@@ -13,7 +13,7 @@ export async function performScanDiagnostic(
   store: Store,
   logger: Logger
 ): Promise<ScanDiagnosticOutcome> {
-  await logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
+  void logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
     message:
       'Starting diagnostic scan. Test sheet should be a blank sheet of white paper.',
   });
@@ -28,7 +28,7 @@ export async function performScanDiagnostic(
   await batchControl.endBatch();
 
   if (!sheets) {
-    await logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
+    void logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
       disposition: 'failure',
       message: 'No test sheet detected for scan diagnostic.',
     });
@@ -49,7 +49,7 @@ export async function performScanDiagnostic(
       type: 'blank-sheet-scan',
       outcome: 'pass',
     });
-    await logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
+    void logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
       disposition: 'success',
       message: 'Diagnostic scan succeeded.',
     });
@@ -58,7 +58,7 @@ export async function performScanDiagnostic(
       type: 'blank-sheet-scan',
       outcome: 'fail',
     });
-    await logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
+    void logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
       disposition: 'failure',
       message:
         'Diagnostic scan failed. The paper may not be blank or the scanner may need to be cleaned.',

--- a/apps/central-scan/backend/importer/importer.ts
+++ b/apps/central-scan/backend/importer/importer.ts
@@ -181,7 +181,7 @@ export class Importer {
     );
 
     const batch = this.workspace.store.getBatch(batchId);
-    await logScanSheetSuccess(this.logger, batch);
+    void logScanSheetSuccess(this.logger, batch);
 
     return sheetId;
   }
@@ -264,7 +264,7 @@ export class Importer {
     if (this.batchId) {
       this.workspace.store.finishBatch({ batchId: this.batchId, error });
       const batch = this.workspace.store.getBatch(this.batchId);
-      await logBatchComplete(this.logger, batch);
+      void logBatchComplete(this.logger, batch);
       this.batchId = undefined;
     }
 

--- a/apps/central-scan/backend/reports/readiness_report.ts
+++ b/apps/central-scan/backend/reports/readiness_report.ts
@@ -61,12 +61,12 @@ export async function saveReadinessReport({
   );
 
   if (exportFileResult.isOk()) {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `User saved the equipment readiness report to a USB drive.`,
       disposition: 'success',
     });
   } else {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `Error while attempting to save the equipment readiness report to a USB drive: ${
         exportFileResult.err().message
       }`,

--- a/apps/central-scan/backend/workspace/workspace.ts
+++ b/apps/central-scan/backend/workspace/workspace.ts
@@ -6,6 +6,7 @@ import {
 } from '@vx/libs/backend/diagnostics';
 import { BaseLogger } from '@vx/libs/logging/src';
 import { Store } from '../store/store';
+import { isIntegrationTest } from '@vx/libs/utils/src';
 
 export interface Workspace {
   /**
@@ -64,7 +65,10 @@ export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
-  const store = Store.fileStore(dbPath, logger);
+  const store =
+    process.env.NODE_ENV === 'test' || isIntegrationTest()
+      ? Store.memoryStore()
+      : Store.fileStore(dbPath, logger);
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(
     store,
     [resolvedRoot]

--- a/apps/central-scan/integration-testing/e2e/configuration.spec.ts
+++ b/apps/central-scan/integration-testing/e2e/configuration.spec.ts
@@ -16,7 +16,7 @@ test('configure + scan', async ({ page }) => {
   const { electionDefinition } =
     electionGridLayoutNewHampshireTestBallotFixtures;
 
-  await logInAsElectionManager(page, electionDefinition.election);
+  void logInAsElectionManager(page, electionDefinition.election);
 
   usbHandler.insert(
     await mockElectionPackageFileTree(

--- a/apps/design/backend/app/app.ts
+++ b/apps/design/backend/app/app.ts
@@ -102,7 +102,7 @@ export function convertVxfPrecincts(election: Election): Precinct[] {
   });
 }
 
-function buildApi({ workspace, translator }: AppContext) {
+function buildApiInternal({ workspace, translator }: AppContext) {
   const { store } = workspace;
 
   return grout.createApi({
@@ -357,7 +357,11 @@ function buildApi({ workspace, translator }: AppContext) {
     },
   });
 }
-export type Api = ReturnType<typeof buildApi>;
+export type Api = ReturnType<typeof buildApiInternal>;
+
+export function buildApi(context: AppContext): Api {
+  return buildApiInternal(context);
+}
 
 export function buildApp(context: AppContext): Application {
   const app: Application = express();

--- a/apps/design/backend/app/workspace.ts
+++ b/apps/design/backend/app/workspace.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import { BaseLogger } from '@vx/libs/logging/src';
 import { Store } from '../store/store';
+import { isIntegrationTest } from '@vx/libs/utils/src';
 
 export interface Workspace {
   assetDirectoryPath: string;
@@ -19,7 +20,10 @@ export function createWorkspace(
   ensureDirSync(assetDirectoryPath);
 
   const dbPath = join(workspacePath, 'design-backend.db');
-  const store = Store.fileStore(dbPath, logger);
+  const store =
+    process.env.NODE_ENV === 'test' || isIntegrationTest()
+      ? Store.memoryStore()
+      : Store.fileStore(dbPath, logger);
 
   return { assetDirectoryPath, store };
 }

--- a/apps/design/backend/app_tests/part-1/crud.test.ts
+++ b/apps/design/backend/app_tests/part-1/crud.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
   );
 });
 
-test('CRUD elections', async () => {
+test('CRUD elections', () => {
   const { api } = newTestApi();
   expect(api.listElections()).toEqual([]);
 

--- a/apps/design/backend/app_tests/part-2/rotation.test.ts
+++ b/apps/design/backend/app_tests/part-2/rotation.test.ts
@@ -25,22 +25,18 @@ import {
   getFeatureFlagMock,
 } from '@vx/libs/utils/src';
 import { mockOf } from '@vx/libs/test-utils/src';
-import { testSetupHelpers } from '../../test/helpers';
+import { newTestApi } from '../../test/helpers';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-const { setupApp, cleanup } = testSetupHelpers();
-
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
   MOCK_READINESS_REPORT_CONTENTS,
   'utf-8'
 );
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -53,15 +49,15 @@ beforeEach(() => {
   );
 });
 
-test('Updating contests with candidate rotation', async () => {
-  const { apiClient } = setupApp();
-  const electionId = (
-    await apiClient.loadElection({
+test('Updating contests with candidate rotation', () => {
+  const { api } = newTestApi();
+  const electionId = api
+    .loadElection({
       electionData:
         electionFamousNames2021Fixtures.electionDefinition.electionData,
     })
-  ).unsafeUnwrap();
-  const electionRecord = await apiClient.getElection({ electionId });
+    .unsafeUnwrap();
+  const electionRecord = api.getElection({ electionId });
   const contest = electionRecord.election.contests.find(
     (c): c is CandidateContest =>
       c.type === 'candidate' && c.candidates.length > 2
@@ -75,12 +71,12 @@ test('Updating contests with candidate rotation', async () => {
 `);
 
   // Update with no changes just to trigger candidate rotation
-  await apiClient.updateElection({
+  api.updateElection({
     electionId,
     election: electionRecord.election,
   });
 
-  const updatedElectionRecord = await apiClient.getElection({ electionId });
+  const updatedElectionRecord = api.getElection({ electionId });
   const updatedContest = updatedElectionRecord.election.contests.find(
     (c): c is CandidateContest => c.id === contest.id
   )!;

--- a/apps/design/backend/app_tests/part-3/settings.test.ts
+++ b/apps/design/backend/app_tests/part-3/settings.test.ts
@@ -29,22 +29,18 @@ import {
   getFeatureFlagMock,
 } from '@vx/libs/utils/src';
 import { mockOf } from '@vx/libs/test-utils/src';
-import { testSetupHelpers } from '../../test/helpers';
+import { newTestApi } from '../../test/helpers';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-const { setupApp, cleanup } = testSetupHelpers();
-
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
   MOCK_READINESS_REPORT_CONTENTS,
   'utf-8'
 );
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -57,11 +53,11 @@ beforeEach(() => {
   );
 });
 
-test('Update system settings', async () => {
-  const { apiClient } = setupApp();
+test('Update system settings', () => {
+  const { api } = newTestApi();
   const electionId = 'election-1' as ElectionId;
-  (await apiClient.createElection({ id: electionId })).unsafeUnwrap();
-  const electionRecord = await apiClient.getElection({ electionId });
+  api.createElection({ id: electionId }).unsafeUnwrap();
+  const electionRecord = api.getElection({ electionId });
 
   expect(electionRecord.systemSettings).toEqual(DEFAULT_SYSTEM_SETTINGS);
 
@@ -79,12 +75,12 @@ test('Update system settings', async () => {
   };
   expect(updatedSystemSettings).not.toEqual(DEFAULT_SYSTEM_SETTINGS);
 
-  await apiClient.updateSystemSettings({
+  api.updateSystemSettings({
     electionId,
     systemSettings: updatedSystemSettings,
   });
 
-  expect(await apiClient.getElection({ electionId })).toEqual({
+  expect(api.getElection({ electionId })).toEqual({
     ...electionRecord,
     systemSettings: updatedSystemSettings,
   });

--- a/apps/design/backend/app_tests/part-5/package_export.test.ts
+++ b/apps/design/backend/app_tests/part-5/package_export.test.ts
@@ -52,7 +52,7 @@ import {
   exportElectionPackage,
   isMockCloudSynthesizedSpeech,
   mockCloudTranslatedText,
-  testSetupHelpers,
+  newTestApi,
 } from '../../test/helpers';
 import { forEachUiString } from '../../language_and_audio/utils/utils';
 import { getAllBallotLanguages } from '../../types/types';
@@ -61,8 +61,6 @@ import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_sty
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
-
-const { setupApp, cleanup } = testSetupHelpers();
 
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
@@ -80,8 +78,6 @@ function expectedEnglishBallotStrings(election: Election): UiStringsPackage {
   );
   return expectedStrings;
 }
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -113,23 +109,23 @@ test('Election package export', async () => {
       AdjudicationReason.UnmarkedWriteIn,
     ],
   };
-  const { apiClient, workspace } = setupApp();
+  const { api, workspace } = newTestApi();
 
-  const electionId = (
-    await apiClient.loadElection({
+  const electionId = api
+    .loadElection({
       electionData: JSON.stringify(electionWithLegalPaper),
     })
-  ).unsafeUnwrap();
-  await apiClient.updateSystemSettings({
+    .unsafeUnwrap();
+  api.updateSystemSettings({
     electionId,
     systemSettings: mockSystemSettings,
   });
-  const electionRecord = await apiClient.getElection({ electionId });
+  const electionRecord = api.getElection({ electionId });
 
   const { ballotLanguageConfigs, election: appElection } = electionRecord;
 
   const electionPackageFilePath = await exportElectionPackage({
-    apiClient,
+    api,
     electionId,
     workspace,
     electionSerializationFormat: 'vxf',

--- a/apps/design/backend/app_tests/part-6/ballot_export.test.ts
+++ b/apps/design/backend/app_tests/part-6/ballot_export.test.ts
@@ -39,15 +39,13 @@ import {
   renderAllBallotsAndCreateElectionDefinition,
   vxDefaultBallotTemplate,
 } from '@vx/libs/hmpb/src';
-import { testSetupHelpers } from '../../test/helpers';
+import { newTestApi } from '../../test/helpers';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 import { BALLOT_STYLE_READINESS_REPORT_FILE_NAME } from '../../app/app';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
-
-const { setupApp, cleanup } = testSetupHelpers();
 
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
@@ -65,8 +63,6 @@ function expectedEnglishBallotStrings(election: Election): UiStringsPackage {
   );
   return expectedStrings;
 }
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -88,18 +84,18 @@ test('Export all ballots', async () => {
 
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.electionDefinition;
-  const { apiClient } = setupApp();
+  const { api } = newTestApi();
 
-  const electionId = (
-    await apiClient.loadElection({
+  const electionId = api
+    .loadElection({
       electionData: baseElectionDefinition.electionData,
     })
-  ).unsafeUnwrap();
-  const { ballotStyles, election, precincts } = await apiClient.getElection({
+    .unsafeUnwrap();
+  const { ballotStyles, election, precincts } = api.getElection({
     electionId,
   });
 
-  const { zipContents } = await apiClient.exportAllBallots({
+  const { zipContents } = await api.exportAllBallots({
     electionId,
     electionSerializationFormat: 'vxf',
   });

--- a/apps/design/backend/app_tests/part-7/test_deck_export.test.ts
+++ b/apps/design/backend/app_tests/part-7/test_deck_export.test.ts
@@ -37,15 +37,13 @@ import {
   renderAllBallotsAndCreateElectionDefinition,
   vxDefaultBallotTemplate,
 } from '@vx/libs/hmpb/src';
-import { testSetupHelpers } from '../../test/helpers';
+import { newTestApi } from '../../test/helpers';
 import { FULL_TEST_DECK_TALLY_REPORT_FILE_NAME } from '../../test-decks/test_decks';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
-
-const { setupApp, cleanup } = testSetupHelpers();
 
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
@@ -63,8 +61,6 @@ function expectedEnglishBallotStrings(election: Election): UiStringsPackage {
   );
   return expectedStrings;
 }
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -85,16 +81,16 @@ test('Export test decks', async () => {
   );
 
   const electionDefinition = electionTwoPartyPrimaryDefinition;
-  const { apiClient } = setupApp();
+  const { api } = newTestApi();
 
-  const electionId = (
-    await apiClient.loadElection({
+  const electionId = api
+    .loadElection({
       electionData: electionDefinition.electionData,
     })
-  ).unsafeUnwrap();
-  const { election } = await apiClient.getElection({ electionId });
+    .unsafeUnwrap();
+  const { election } = api.getElection({ electionId });
 
-  const { zipContents } = await apiClient.exportTestDecks({
+  const { zipContents } = await api.exportTestDecks({
     electionId,
     electionSerializationFormat: 'vxf',
   });

--- a/apps/design/backend/app_tests/part-8/hash_consistency.test.ts
+++ b/apps/design/backend/app_tests/part-8/hash_consistency.test.ts
@@ -25,22 +25,18 @@ import {
 } from '@vx/libs/utils/src';
 import { readElectionPackageFromFile } from '@vx/libs/backend/election_package';
 import { mockOf } from '@vx/libs/test-utils/src';
-import { exportElectionPackage, testSetupHelpers } from '../../test/helpers';
+import { exportElectionPackage, newTestApi } from '../../test/helpers';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-const { setupApp, cleanup } = testSetupHelpers();
-
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
   MOCK_READINESS_REPORT_CONTENTS,
   'utf-8'
 );
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -62,26 +58,26 @@ test('Consistency of ballot hash across exports', async () => {
 
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.electionDefinition;
-  const { apiClient, workspace } = setupApp();
+  const { api, workspace } = newTestApi();
 
-  const electionId = (
-    await apiClient.loadElection({
+  const electionId = api
+    .loadElection({
       electionData: baseElectionDefinition.electionData,
     })
-  ).unsafeUnwrap();
+    .unsafeUnwrap();
 
-  const allBallotsOutput = await apiClient.exportAllBallots({
+  const allBallotsOutput = await api.exportAllBallots({
     electionId,
     electionSerializationFormat: 'vxf',
   });
 
-  const testDecksOutput = await apiClient.exportTestDecks({
+  const testDecksOutput = await api.exportTestDecks({
     electionId,
     electionSerializationFormat: 'vxf',
   });
 
   const electionPackageFilePath = await exportElectionPackage({
-    apiClient,
+    api,
     electionId,
     workspace,
     electionSerializationFormat: 'vxf',

--- a/apps/design/backend/app_tests/part-9/cdf_export.test.ts
+++ b/apps/design/backend/app_tests/part-9/cdf_export.test.ts
@@ -25,22 +25,18 @@ import {
 } from '@vx/libs/utils/src';
 import { readElectionPackageFromFile } from '@vx/libs/backend/election_package';
 import { mockOf } from '@vx/libs/test-utils/src';
-import { exportElectionPackage, testSetupHelpers } from '../../test/helpers';
+import { exportElectionPackage, newTestApi } from '../../test/helpers';
 import { renderBallotStyleReadinessReport } from '../../ballot-styles/ballot_style_reports';
 
 jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-const { setupApp, cleanup } = testSetupHelpers();
-
 const MOCK_READINESS_REPORT_CONTENTS = '%PDF - MockReadinessReport';
 const MOCK_READINESS_REPORT_PDF = Buffer.from(
   MOCK_READINESS_REPORT_CONTENTS,
   'utf-8'
 );
-
-afterAll(cleanup);
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
@@ -62,26 +58,26 @@ test('CDF exports', async () => {
 
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.electionDefinition;
-  const { apiClient, workspace } = setupApp();
+  const { api, workspace } = newTestApi();
 
-  const electionId = (
-    await apiClient.loadElection({
+  const electionId = api
+    .loadElection({
       electionData: baseElectionDefinition.electionData,
     })
-  ).unsafeUnwrap();
+    .unsafeUnwrap();
 
-  const allBallotsOutput = await apiClient.exportAllBallots({
+  const allBallotsOutput = await api.exportAllBallots({
     electionId,
     electionSerializationFormat: 'cdf',
   });
 
-  const testDecksOutput = await apiClient.exportTestDecks({
+  const testDecksOutput = await api.exportTestDecks({
     electionId,
     electionSerializationFormat: 'cdf',
   });
 
   const electionPackageFilePath = await exportElectionPackage({
-    apiClient,
+    api,
     electionId,
     workspace,
     electionSerializationFormat: 'cdf',

--- a/apps/mark-scan/backend/app/app.ts
+++ b/apps/mark-scan/backend/app/app.ts
@@ -155,7 +155,7 @@ export function buildApi(
       return workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
     },
 
-    async unconfigureMachine() {
+    unconfigureMachine() {
       workspace.store.reset();
       void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
@@ -300,7 +300,7 @@ export function buildApi(
       assertDefined(stateMachine).returnPreprintedBallot();
     },
 
-    async confirmInvalidateBallot(): Promise<void> {
+    confirmInvalidateBallot(): void {
       assert(stateMachine);
 
       void logger.log(LogEventId.BallotInvalidated, 'poll_worker');
@@ -384,7 +384,7 @@ export function buildApi(
       void logger.logAsCurrentRole(logEvent, { disposition: 'success' });
     },
 
-    async setTestMode(input: { isTestMode: boolean }) {
+    setTestMode(input: { isTestMode: boolean }) {
       const logMessage = input.isTestMode
         ? 'official to test'
         : 'test to official';
@@ -402,9 +402,9 @@ export function buildApi(
       });
     },
 
-    async setPrecinctSelection(input: {
+    setPrecinctSelection(input: {
       precinctSelection: PrecinctSelection;
-    }): Promise<void> {
+    }): void {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
       store.setBallotsPrintedCount(0);

--- a/apps/mark-scan/backend/app/app.ts
+++ b/apps/mark-scan/backend/app/app.ts
@@ -157,7 +157,7 @@ export function buildApi(
 
     async unconfigureMachine() {
       workspace.store.reset();
-      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
           'User successfully unconfigured the machine to remove the current election.',
@@ -177,7 +177,7 @@ export function buildApi(
         logger
       );
       if (electionPackageResult.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
           disposition: 'failure',
           message: 'Error configuring machine.',
           errorDetails: JSON.stringify(electionPackageResult.err()),
@@ -214,7 +214,7 @@ export function buildApi(
         });
       });
 
-      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',
         ballotHash: electionDefinition.ballotHash,
@@ -303,7 +303,7 @@ export function buildApi(
     async confirmInvalidateBallot(): Promise<void> {
       assert(stateMachine);
 
-      await logger.log(LogEventId.BallotInvalidated, 'poll_worker');
+      void logger.log(LogEventId.BallotInvalidated, 'poll_worker');
 
       stateMachine.confirmInvalidateBallot();
     },
@@ -319,7 +319,7 @@ export function buildApi(
       workspace.store.setBallotsCastSinceLastBoxChange(0);
       stateMachine.confirmBallotBoxEmptied();
 
-      await logger.log(LogEventId.BallotBoxEmptied, 'poll_worker');
+      void logger.log(LogEventId.BallotBoxEmptied, 'poll_worker');
     },
 
     ...createUiStringsApi({
@@ -381,21 +381,21 @@ export function buildApi(
         }
       })();
 
-      await logger.logAsCurrentRole(logEvent, { disposition: 'success' });
+      void logger.logAsCurrentRole(logEvent, { disposition: 'success' });
     },
 
     async setTestMode(input: { isTestMode: boolean }) {
       const logMessage = input.isTestMode
         ? 'official to test'
         : 'test to official';
-      await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
+      void logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling from ${logMessage} mode`,
         isTestMode: input.isTestMode,
       });
       store.setTestMode(input.isTestMode);
       store.setPollsState('polls_closed_initial');
       store.setBallotsPrintedCount(0);
-      await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
+      void logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
         disposition: 'success',
         message: `Successfully toggled from ${logMessage} mode.`,
         isTestMode: input.isTestMode,
@@ -408,7 +408,7 @@ export function buildApi(
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
       store.setBallotsPrintedCount(0);
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -465,13 +465,13 @@ export function buildApi(
     async generateSignedHashValidationQrCodeValue() {
       const { codeVersion, machineId } = getMachineConfig();
       const electionRecord = store.getElectionRecord();
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
       const qrCodeValue = await generateSignedHashValidationQrCodeValue({
         electionRecord,
         machineId,
         softwareVersion: codeVersion,
       });
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
         disposition: 'success',
       });
       return qrCodeValue;

--- a/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
@@ -493,7 +493,7 @@ export function buildMachine(
 
           return { type: 'PAT_DEVICE_NO_STATUS_CHANGE' };
         } catch (err) {
-          await logger.log(LogEventId.PatDeviceError, 'system', {
+          void logger.log(LogEventId.PatDeviceError, 'system', {
             error: (err as Error).message,
             disposition: 'failure',
           });
@@ -533,7 +533,7 @@ export function buildMachine(
           /* istanbul ignore next - unreachable if exhaustive */
           return { type: 'AUTH_STATUS_UNHANDLED' };
         } catch (err) {
-          await logger.log(LogEventId.UnknownError, 'system', {
+          void logger.log(LogEventId.UnknownError, 'system', {
             error: (err as Error).message,
             disposition: 'failure',
           });
@@ -1437,7 +1437,7 @@ function setUpLogging(
       if (event.type !== 'PAT_DEVICE_NO_STATUS_CHANGE') {
         // This event was triggered by a user action and should be logged with the current role.
         if (isEventUserAction(event)) {
-          await logger.logAsCurrentRole(
+          void logger.logAsCurrentRole(
             LogEventId.MarkScanStateMachineEvent,
             { message: `Event: ${event.type}` },
             /* istanbul ignore next */
@@ -1445,7 +1445,7 @@ function setUpLogging(
           );
         } else {
           // Non-user driven events can be logged with a user of 'system'
-          await logger.log(
+          void logger.log(
             LogEventId.MarkScanStateMachineEvent,
             'system',
             { message: `Event: ${event.type}` },
@@ -1488,7 +1488,7 @@ function setUpLogging(
         ]);
 
       if (changed.length === 0) return;
-      await logger.log(
+      void logger.log(
         LogEventId.PaperHandlerStateChanged,
         'system',
         {
@@ -1501,7 +1501,7 @@ function setUpLogging(
     })
     .onTransition(async (state) => {
       if (!state.changed) return;
-      await logger.log(
+      void logger.log(
         LogEventId.PaperHandlerStateChanged,
         'system',
         {

--- a/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
@@ -1431,7 +1431,7 @@ function setUpLogging(
   logger: Logger
 ) {
   machineService
-    .onEvent(async (event) => {
+    .onEvent((event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
       if (event.type !== 'PAT_DEVICE_NO_STATUS_CHANGE') {
@@ -1455,7 +1455,7 @@ function setUpLogging(
         }
       }
     })
-    .onChange(async (context, previousContext) => {
+    .onChange((context, previousContext) => {
       if (!previousContext) return;
       const changed = Object.entries(context)
         .filter(
@@ -1499,7 +1499,7 @@ function setUpLogging(
         () => debug('Context updated: %o', Object.fromEntries(changed))
       );
     })
-    .onTransition(async (state) => {
+    .onTransition((state) => {
       if (!state.changed) return;
       void logger.log(
         LogEventId.PaperHandlerStateChanged,

--- a/apps/mark-scan/backend/reports/readiness_report.ts
+++ b/apps/mark-scan/backend/reports/readiness_report.ts
@@ -100,12 +100,12 @@ export async function saveReadinessReport({
     data
   );
   if (exportFileResult.isOk()) {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `User saved the equipment readiness report to a USB drive.`,
       disposition: 'success',
     });
   } else {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `Error while attempting to save the equipment readiness report to a USB drive: ${
         exportFileResult.err().message
       }`,

--- a/apps/mark-scan/backend/server/server.ts
+++ b/apps/mark-scan/backend/server/server.ts
@@ -121,7 +121,7 @@ export async function start({
   return app.listen(
     port,
     /* istanbul ignore next */
-    async () => {
+    () => {
       void logger.log(LogEventId.ApplicationStartup, 'system', {
         message: `VxMarkScan backend running at http://localhost:${port}/`,
         disposition: 'success',

--- a/apps/mark-scan/backend/server/server.ts
+++ b/apps/mark-scan/backend/server/server.ts
@@ -38,7 +38,7 @@ export async function resolveDriver(
   if (
     isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_PAPER_HANDLER)
   ) {
-    await logger.log(LogEventId.PaperHandlerConnection, 'system', {
+    void logger.log(LogEventId.PaperHandlerConnection, 'system', {
       message: 'Starting server with mock paper handler',
     });
     return new MockPaperHandlerDriver();
@@ -53,13 +53,13 @@ export async function resolveDriver(
   const driver = await getPaperHandlerDriver({ maxPrintWidth });
 
   if (driver) {
-    await logger.log(LogEventId.PaperHandlerConnection, 'system', {
+    void logger.log(LogEventId.PaperHandlerConnection, 'system', {
       disposition: 'success',
     });
     return driver;
   }
 
-  await logger.log(LogEventId.PaperHandlerConnection, 'system', {
+  void logger.log(LogEventId.PaperHandlerConnection, 'system', {
     disposition: 'failure',
   });
   return undefined;
@@ -122,7 +122,7 @@ export async function start({
     port,
     /* istanbul ignore next */
     async () => {
-      await logger.log(LogEventId.ApplicationStartup, 'system', {
+      void logger.log(LogEventId.ApplicationStartup, 'system', {
         message: `VxMarkScan backend running at http://localhost:${port}/`,
         disposition: 'success',
       });

--- a/apps/mark-scan/backend/util/hardware.ts
+++ b/apps/mark-scan/backend/util/hardware.ts
@@ -29,7 +29,7 @@ export async function isAccessibleControllerDaemonRunning(
   });
 
   if (readResult.isErr()) {
-    await logger.log(LogEventId.NoPid, 'system', {
+    void logger.log(LogEventId.NoPid, 'system', {
       message: 'Unable to read accessible controller daemon PID file',
       error: JSON.stringify(readResult.err()),
     });
@@ -39,7 +39,7 @@ export async function isAccessibleControllerDaemonRunning(
   const pidString = readResult.ok();
   const pidResult = safeParseInt(pidString);
   if (pidResult.isErr()) {
-    await logger.log(LogEventId.ParseError, 'system', {
+    void logger.log(LogEventId.ParseError, 'system', {
       message: `Unable to parse accessible controller daemon PID: ${pidString}`,
       disposition: 'failure',
     });
@@ -55,17 +55,17 @@ export async function isAccessibleControllerDaemonRunning(
   } catch (error) {
     switch ((error as NodeJS.ErrnoException).code) {
       case 'ESRCH':
-        await logger.log(LogEventId.NoPid, 'system', {
+        void logger.log(LogEventId.NoPid, 'system', {
           message: `Process with PID ${pid} is not running`,
         });
         return false;
       case 'EPERM':
-        await logger.log(LogEventId.PermissionDenied, 'system', {
+        void logger.log(LogEventId.PermissionDenied, 'system', {
           message: 'Permission denied to check PID',
         });
         return false;
       default:
-        await logger.log(LogEventId.UnknownError, 'system', {
+        void logger.log(LogEventId.UnknownError, 'system', {
           message: 'Unknown error when checking PID',
           error: JSON.stringify(error),
           disposition: 'failure',

--- a/apps/mark-scan/backend/util/workspace.ts
+++ b/apps/mark-scan/backend/util/workspace.ts
@@ -6,6 +6,7 @@ import {
 } from '@vx/libs/backend/diagnostics';
 import { BaseLogger } from '@vx/libs/logging/src';
 import { Store } from '../store/store';
+import { isIntegrationTest } from '@vx/libs/utils/src';
 
 export interface Workspace {
   /**
@@ -39,7 +40,11 @@ export function createWorkspace(
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'mark.db');
-  const store = options.store || Store.fileStore(dbPath, logger);
+  const store = options.store
+    ? options.store
+    : process.env.NODE_ENV === 'test' || isIntegrationTest()
+    ? Store.memoryStore()
+    : Store.fileStore(dbPath, logger);
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(
     store,
     [resolvedRoot]

--- a/apps/mark/backend/app/app.ts
+++ b/apps/mark/backend/app/app.ts
@@ -123,7 +123,7 @@ export function buildApi(
       return workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
     },
 
-    async unconfigureMachine() {
+    unconfigureMachine() {
       workspace.store.reset();
       void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
@@ -212,7 +212,7 @@ export function buildApi(
       });
     },
 
-    async setPollsState(input: { pollsState: PollsState }) {
+    setPollsState(input: { pollsState: PollsState }) {
       const newPollsState = input.pollsState;
       const oldPollsState = store.getPollsState();
 
@@ -248,9 +248,9 @@ export function buildApi(
       store.setBallotsPrintedCount(0);
     },
 
-    async setPrecinctSelection(input: {
+    setPrecinctSelection(input: {
       precinctSelection: PrecinctSelection;
-    }): Promise<void> {
+    }): void {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
       store.setBallotsPrintedCount(0);

--- a/apps/mark/backend/app/app.ts
+++ b/apps/mark/backend/app/app.ts
@@ -125,7 +125,7 @@ export function buildApi(
 
     async unconfigureMachine() {
       workspace.store.reset();
-      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
           'User successfully unconfigured the machine to remove the current election.',
@@ -145,7 +145,7 @@ export function buildApi(
         logger
       );
       if (electionPackageResult.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
           disposition: 'failure',
           message: 'Error configuring machine.',
           errorDetails: JSON.stringify(electionPackageResult.err()),
@@ -182,7 +182,7 @@ export function buildApi(
         });
       });
 
-      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',
         ballotHash: electionDefinition.ballotHash,
@@ -239,7 +239,7 @@ export function buildApi(
         }
       })();
 
-      await logger.logAsCurrentRole(logEvent, { disposition: 'success' });
+      void logger.logAsCurrentRole(logEvent, { disposition: 'success' });
     },
 
     setTestMode(input: { isTestMode: boolean }) {
@@ -254,7 +254,7 @@ export function buildApi(
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
       store.setBallotsPrintedCount(0);
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,

--- a/apps/mark/backend/server/server.ts
+++ b/apps/mark/backend/server/server.ts
@@ -61,7 +61,7 @@ export async function start({
   return app.listen(
     port,
     /* istanbul ignore next */
-    async () => {
+    () => {
       void logger.log(LogEventId.ApplicationStartup, 'system', {
         message: `VxMark backend running at http://localhost:${port}/`,
         disposition: 'success',

--- a/apps/mark/backend/server/server.ts
+++ b/apps/mark/backend/server/server.ts
@@ -62,7 +62,7 @@ export async function start({
     port,
     /* istanbul ignore next */
     async () => {
-      await logger.log(LogEventId.ApplicationStartup, 'system', {
+      void logger.log(LogEventId.ApplicationStartup, 'system', {
         message: `VxMark backend running at http://localhost:${port}/`,
         disposition: 'success',
       });

--- a/apps/mark/backend/workspace/workspace.ts
+++ b/apps/mark/backend/workspace/workspace.ts
@@ -2,6 +2,7 @@ import { ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'node:path';
 import { BaseLogger } from '@vx/libs/logging/src';
 import { Store } from '../store/store';
+import { isIntegrationTest } from '@vx/libs/utils/src';
 
 export interface Workspace {
   /**
@@ -30,7 +31,11 @@ export function createWorkspace(
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'mark.db');
-  const store = options.store || Store.fileStore(dbPath, baseLogger);
+  const store = options.store
+    ? options.store
+    : process.env.NODE_ENV === 'test' || isIntegrationTest()
+    ? Store.memoryStore()
+    : Store.fileStore(dbPath, baseLogger);
 
   return {
     path: resolvedRoot,

--- a/apps/scan/backend/app/app.ts
+++ b/apps/scan/backend/app/app.ts
@@ -111,13 +111,13 @@ export function buildApi({
     async generateSignedHashValidationQrCodeValue() {
       const { codeVersion, machineId } = getMachineConfig();
       const electionRecord = store.getElectionRecord();
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationInit);
       const qrCodeValue = await generateSignedHashValidationQrCodeValue({
         electionRecord,
         machineId,
         softwareVersion: codeVersion,
       });
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+      void logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
         disposition: 'success',
       });
       return qrCodeValue;
@@ -155,7 +155,7 @@ export function buildApi({
         logger
       );
       if (electionPackageResult.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
           disposition: 'failure',
           message: 'Error configuring machine.',
           errorDetails: JSON.stringify(electionPackageResult.err()),
@@ -193,7 +193,7 @@ export function buildApi({
         });
       });
 
-      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',
         ballotHash: electionDefinition.ballotHash,
@@ -231,7 +231,7 @@ export function buildApi({
 
     async unconfigureElection(): Promise<void> {
       workspace.reset();
-      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+      void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
           'User successfully unconfigured the machine to remove the current election and all current ballot data.',
@@ -248,7 +248,7 @@ export function buildApi({
       );
       store.setPrecinctSelection(input.precinctSelection);
       workspace.resetElectionSession();
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -259,7 +259,7 @@ export function buildApi({
 
     async setIsSoundMuted(input: { isSoundMuted: boolean }): Promise<void> {
       store.setIsSoundMuted(input.isSoundMuted);
-      await logger.logAsCurrentRole(LogEventId.SoundToggled, {
+      void logger.logAsCurrentRole(LogEventId.SoundToggled, {
         message: `Sounds were toggled ${input.isSoundMuted ? 'off' : 'on'}`,
         disposition: 'success',
         isSoundMuted: input.isSoundMuted,
@@ -272,7 +272,7 @@ export function buildApi({
       store.setIsDoubleFeedDetectionDisabled(
         input.isDoubleFeedDetectionDisabled
       );
-      await logger.logAsCurrentRole(LogEventId.DoubleSheetDetectionToggled, {
+      void logger.logAsCurrentRole(LogEventId.DoubleSheetDetectionToggled, {
         message: `Double sheet detection was toggled ${
           input.isDoubleFeedDetectionDisabled ? 'off' : 'on'
         }`,
@@ -285,7 +285,7 @@ export function buildApi({
       isContinuousExportEnabled: boolean;
     }): Promise<void> {
       store.setIsContinuousExportEnabled(input.isContinuousExportEnabled);
-      await logger.logAsCurrentRole(LogEventId.ContinuousExportToggled, {
+      void logger.logAsCurrentRole(LogEventId.ContinuousExportToggled, {
         message: `Continuous export was ${
           input.isContinuousExportEnabled ? 'resumed' : 'paused'
         }`,
@@ -297,7 +297,7 @@ export function buildApi({
       const logMessage = input.isTestMode
         ? 'official to test'
         : 'test to official';
-      await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
+      void logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling from ${logMessage} mode`,
         isTestMode: input.isTestMode,
       });
@@ -307,7 +307,7 @@ export function buildApi({
         workspace.resetElectionSession()
       );
       store.setTestMode(input.isTestMode);
-      await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
+      void logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
         disposition: 'success',
         message: `Successfully toggled from ${logMessage} mode.`,
         isTestMode: input.isTestMode,

--- a/apps/scan/backend/app/app.ts
+++ b/apps/scan/backend/app/app.ts
@@ -68,8 +68,7 @@ import {
 import { saveReadinessReport } from '../printing/readiness_report';
 import path from 'node:path';
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function buildApi({
+function buildApiInternal({
   auth,
   machine,
   workspace,
@@ -229,7 +228,7 @@ export function buildApi({
       };
     },
 
-    async unconfigureElection(): Promise<void> {
+    unconfigureElection(): void {
       workspace.reset();
       void logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
@@ -238,9 +237,9 @@ export function buildApi({
       });
     },
 
-    async setPrecinctSelection(input: {
+    setPrecinctSelection(input: {
       precinctSelection: PrecinctSelection;
-    }): Promise<void> {
+    }): void {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       assert(
         store.getBallotsCounted() === 0,
@@ -257,7 +256,7 @@ export function buildApi({
       });
     },
 
-    async setIsSoundMuted(input: { isSoundMuted: boolean }): Promise<void> {
+    setIsSoundMuted(input: { isSoundMuted: boolean }): void {
       store.setIsSoundMuted(input.isSoundMuted);
       void logger.logAsCurrentRole(LogEventId.SoundToggled, {
         message: `Sounds were toggled ${input.isSoundMuted ? 'off' : 'on'}`,
@@ -266,9 +265,9 @@ export function buildApi({
       });
     },
 
-    async setIsDoubleFeedDetectionDisabled(input: {
+    setIsDoubleFeedDetectionDisabled(input: {
       isDoubleFeedDetectionDisabled: boolean;
-    }): Promise<void> {
+    }): void {
       store.setIsDoubleFeedDetectionDisabled(
         input.isDoubleFeedDetectionDisabled
       );
@@ -281,9 +280,9 @@ export function buildApi({
       });
     },
 
-    async setIsContinuousExportEnabled(input: {
+    setIsContinuousExportEnabled(input: {
       isContinuousExportEnabled: boolean;
-    }): Promise<void> {
+    }): void {
       store.setIsContinuousExportEnabled(input.isContinuousExportEnabled);
       void logger.logAsCurrentRole(LogEventId.ContinuousExportToggled, {
         message: `Continuous export was ${
@@ -314,7 +313,7 @@ export function buildApi({
       });
     },
 
-    openPolls(): Promise<OpenPollsResult> {
+    openPolls(): OpenPollsResult {
       return openPolls({ store, logger });
     },
 
@@ -322,16 +321,16 @@ export function buildApi({
       return closePolls({ workspace, usbDrive, logger });
     },
 
-    pauseVoting(): Promise<void> {
-      return pauseVoting({ store, logger });
+    pauseVoting(): void {
+      pauseVoting({ store, logger });
     },
 
-    resumeVoting(): Promise<void> {
-      return resumeVoting({ store, logger });
+    resumeVoting(): void {
+      resumeVoting({ store, logger });
     },
 
-    resetPollsToPaused(): Promise<void> {
-      return resetPollsToPaused({ store, logger });
+    resetPollsToPaused(): void {
+      resetPollsToPaused({ store, logger });
     },
 
     exportCastVoteRecordsToUsbDrive(input: {
@@ -525,7 +524,18 @@ export function buildApi({
   });
 }
 
-export type Api = ReturnType<typeof buildApi>;
+export type Api = ReturnType<typeof buildApiInternal>;
+
+export function buildApi(params: {
+  auth: InsertedSmartCardAuthApi;
+  machine: PrecinctScannerStateMachine;
+  workspace: Workspace;
+  usbDrive: UsbDrive;
+  printer: Printer;
+  logger: Logger;
+}): Api {
+  return buildApiInternal(params);
+}
 
 export function buildApp({
   auth,

--- a/apps/scan/backend/app/app_auth.test.ts
+++ b/apps/scan/backend/app/app_auth.test.ts
@@ -54,11 +54,11 @@ beforeEach(() => {
 });
 
 test('getAuthStatus', async () => {
-  await withApp(async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive, { electionPackage });
+  await withApp(async ({ api, mockAuth, mockUsbDrive }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { electionPackage });
     mockOf(mockAuth.getAuthStatus).mockClear(); // Clear mock calls from configureApp
 
-    await apiClient.getAuthStatus();
+    await api.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
     expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
       ...systemSettings.auth,
@@ -69,10 +69,10 @@ test('getAuthStatus', async () => {
 });
 
 test('checkPin', async () => {
-  await withApp(async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive, { electionPackage });
+  await withApp(async ({ api, mockAuth, mockUsbDrive }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { electionPackage });
 
-    await apiClient.checkPin({ pin: '123456' });
+    await api.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
     expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
       1,
@@ -83,10 +83,10 @@ test('checkPin', async () => {
 });
 
 test('logOut', async () => {
-  await withApp(async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive, { electionPackage });
+  await withApp(async ({ api, mockAuth, mockUsbDrive }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { electionPackage });
 
-    await apiClient.logOut();
+    await api.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
     expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
       ...systemSettings.auth,
@@ -97,10 +97,10 @@ test('logOut', async () => {
 });
 
 test('updateSessionExpiry', async () => {
-  await withApp(async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive, { electionPackage });
+  await withApp(async ({ api, mockAuth, mockUsbDrive }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { electionPackage });
 
-    await apiClient.updateSessionExpiry({
+    await api.updateSessionExpiry({
       sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
@@ -113,9 +113,9 @@ test('updateSessionExpiry', async () => {
 });
 
 test('getAuthStatus before election definition has been configured', async () => {
-  await withApp(async ({ apiClient, mockAuth }) => {
+  await withApp(async ({ api, mockAuth }) => {
     mockOf(mockAuth.getAuthStatus).mockClear(); // Clear mock calls from state machine
-    await apiClient.getAuthStatus();
+    await api.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
     expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
       1,
@@ -125,8 +125,8 @@ test('getAuthStatus before election definition has been configured', async () =>
 });
 
 test('checkPin before election definition has been configured', async () => {
-  await withApp(async ({ apiClient, mockAuth }) => {
-    await apiClient.checkPin({ pin: '123456' });
+  await withApp(async ({ api, mockAuth }) => {
+    await api.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
     expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
       1,
@@ -137,8 +137,8 @@ test('checkPin before election definition has been configured', async () => {
 });
 
 test('logOut before election definition has been configured', async () => {
-  await withApp(async ({ apiClient, mockAuth }) => {
-    await apiClient.logOut();
+  await withApp(async ({ api, mockAuth }) => {
+    await api.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
     expect(mockAuth.logOut).toHaveBeenNthCalledWith(
       1,
@@ -148,8 +148,8 @@ test('logOut before election definition has been configured', async () => {
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
-  await withApp(async ({ apiClient, mockAuth }) => {
-    await apiClient.updateSessionExpiry({
+  await withApp(async ({ api, mockAuth }) => {
+    await api.updateSessionExpiry({
       sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);

--- a/apps/scan/backend/app/app_legacy_printing.test.ts
+++ b/apps/scan/backend/app/app_legacy_printing.test.ts
@@ -38,7 +38,7 @@ const reportPrintedTime = new Date('2021-01-01T00:00:00.000');
 test('can print and re-print polls opened report', async () => {
   await withApp(
     async ({
-      apiClient,
+      api,
       mockScanner,
       mockUsbDrive,
       mockPrinterHandler,
@@ -47,19 +47,19 @@ test('can print and re-print polls opened report', async () => {
       clock,
     }) => {
       mockPrinterHandler.connectPrinter(BROTHER_THERMAL_PRINTER_CONFIG);
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+      await configureApp(api, mockAuth, mockUsbDrive, {
         testMode: true,
         openPolls: false,
       });
 
       // printing report before polls opened should fail
       await suppressingConsoleOutput(async () => {
-        await expect(apiClient.printReport()).rejects.toThrow();
+        await expect(api.printReport()).rejects.toThrow();
       });
 
       // initial polls opened report
-      (await apiClient.openPolls()).unsafeUnwrap();
-      await apiClient.printReport();
+      (await api.openPolls()).unsafeUnwrap();
+      await api.printReport();
       const initialReportPath = mockPrinterHandler.getLastPrintPath();
       assert(initialReportPath !== undefined);
       await expect(initialReportPath).toMatchPdfSnapshot({
@@ -68,7 +68,7 @@ test('can print and re-print polls opened report', async () => {
       });
 
       // allows re-printing identical polls opened report
-      await apiClient.printReport();
+      await api.printReport();
       const reprintedReportPath = mockPrinterHandler.getLastPrintPath();
       assert(reprintedReportPath !== undefined);
       await expect(reprintedReportPath).toMatchPdfSnapshot({
@@ -77,11 +77,11 @@ test('can print and re-print polls opened report', async () => {
       });
 
       // scan a ballot
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0);
+      await scanBallot(mockScanner, clock, api, workspace.store, 0);
 
       // you should not be able to print polls opened reports after scanning
       await suppressingConsoleOutput(async () => {
-        await expect(apiClient.printReport()).rejects.toThrow();
+        await expect(api.printReport()).rejects.toThrow();
       });
     }
   );
@@ -90,7 +90,7 @@ test('can print and re-print polls opened report', async () => {
 test('can print voting paused and voting resumed reports', async () => {
   await withApp(
     async ({
-      apiClient,
+      api,
       mockScanner,
       mockUsbDrive,
       mockPrinterHandler,
@@ -99,23 +99,23 @@ test('can print voting paused and voting resumed reports', async () => {
       clock,
     }) => {
       mockPrinterHandler.connectPrinter(BROTHER_THERMAL_PRINTER_CONFIG);
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+      await configureApp(api, mockAuth, mockUsbDrive, {
         testMode: true,
       });
 
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0);
+      await scanBallot(mockScanner, clock, api, workspace.store, 0);
 
       // pause voting
-      await apiClient.pauseVoting();
-      await apiClient.printReport();
+      await api.pauseVoting();
+      await api.printReport();
       await expect(mockPrinterHandler.getLastPrintPath()).toMatchPdfSnapshot({
         customSnapshotIdentifier: 'legacy-voting-paused-report',
         failureThreshold: 0.0001,
       });
 
       // resume voting
-      await apiClient.resumeVoting();
-      await apiClient.printReport();
+      await api.resumeVoting();
+      await api.printReport();
       await expect(mockPrinterHandler.getLastPrintPath()).toMatchPdfSnapshot({
         customSnapshotIdentifier: 'legacy-voting-resumed-report',
         failureThreshold: 0.0001,
@@ -127,7 +127,7 @@ test('can print voting paused and voting resumed reports', async () => {
 test('can tabulate results and print polls closed report', async () => {
   await withApp(
     async ({
-      apiClient,
+      api,
       mockScanner,
       mockUsbDrive,
       mockPrinterHandler,
@@ -136,17 +136,17 @@ test('can tabulate results and print polls closed report', async () => {
       clock,
     }) => {
       mockPrinterHandler.connectPrinter(BROTHER_THERMAL_PRINTER_CONFIG);
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+      await configureApp(api, mockAuth, mockUsbDrive, {
         testMode: true,
       });
 
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0);
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 1);
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 2);
+      await scanBallot(mockScanner, clock, api, workspace.store, 0);
+      await scanBallot(mockScanner, clock, api, workspace.store, 1);
+      await scanBallot(mockScanner, clock, api, workspace.store, 2);
 
       // close polls
-      await apiClient.closePolls();
-      await apiClient.printReport();
+      await api.closePolls();
+      await api.printReport();
       await expect(mockPrinterHandler.getLastPrintPath()).toMatchPdfSnapshot({
         customSnapshotIdentifier: 'legacy-polls-closed-report',
         failureThreshold: 0.0001,

--- a/apps/scan/backend/app/app_usb_drive.test.ts
+++ b/apps/scan/backend/app/app_usb_drive.test.ts
@@ -23,13 +23,13 @@ beforeEach(() => {
 });
 
 test('getUsbDriveStatus', async () => {
-  await withApp(async ({ apiClient, mockUsbDrive }) => {
+  await withApp(async ({ api, mockUsbDrive }) => {
     mockUsbDrive.removeUsbDrive();
-    await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    await expect(api.getUsbDriveStatus()).resolves.toEqual({
       status: 'no_drive',
     });
     mockUsbDrive.insertUsbDrive({});
-    await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    await expect(api.getUsbDriveStatus()).resolves.toEqual({
       status: 'mounted',
       mountPoint: expect.any(String),
     });
@@ -37,46 +37,39 @@ test('getUsbDriveStatus', async () => {
 });
 
 test('ejectUsbDrive', async () => {
-  await withApp(async ({ apiClient, mockUsbDrive }) => {
+  await withApp(async ({ api, mockUsbDrive }) => {
     mockUsbDrive.usbDrive.eject.expectCallWith().resolves();
-    await expect(apiClient.ejectUsbDrive()).resolves.toBeUndefined();
+    await expect(api.ejectUsbDrive()).resolves.toBeUndefined();
   });
 });
 
 test('doesUsbDriveRequireCastVoteRecordSync is properly populated', async () => {
   await withApp(
-    async ({
-      apiClient,
-      mockAuth,
-      mockUsbDrive,
-      mockScanner,
-      workspace,
-      clock,
-    }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+    async ({ api, mockAuth, mockUsbDrive, mockScanner, workspace, clock }) => {
+      await configureApp(api, mockAuth, mockUsbDrive, { testMode: true });
       const mountedUsbDriveStatus = {
         status: 'mounted',
         mountPoint: expect.any(String),
       } as const;
 
-      await expect(apiClient.getUsbDriveStatus()).resolves.toEqual(
+      await expect(api.getUsbDriveStatus()).resolves.toEqual(
         mountedUsbDriveStatus
       );
 
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0);
-      await expect(apiClient.getUsbDriveStatus()).resolves.toEqual(
+      await scanBallot(mockScanner, clock, api, workspace.store, 0);
+      await expect(api.getUsbDriveStatus()).resolves.toEqual(
         mountedUsbDriveStatus
       );
 
       mockUsbDrive.removeUsbDrive();
-      await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+      await expect(api.getUsbDriveStatus()).resolves.toEqual({
         status: 'no_drive',
       });
 
       // Insert an empty USB drive and ensure that we detect that it requires a cast vote record
       // sync
       mockUsbDrive.insertUsbDrive({});
-      await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+      await expect(api.getUsbDriveStatus()).resolves.toEqual({
         ...mountedUsbDriveStatus,
         doesUsbDriveRequireCastVoteRecordSync: true,
       });

--- a/apps/scan/backend/export/export.ts
+++ b/apps/scan/backend/export/export.ts
@@ -25,7 +25,7 @@ export async function exportCastVoteRecordsToUsbDrive({
 }): Promise<ExportCastVoteRecordsToUsbDriveResult> {
   const { store, continuousExportMutex } = workspace;
 
-  await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
+  void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
     message:
       mode === 'polls_closing'
         ? 'Marking cast vote record export as complete on polls close...'
@@ -80,7 +80,7 @@ export async function exportCastVoteRecordsToUsbDrive({
           // reason. We have to use a try-catch and can't just check for an error Result
           // because certain errors, e.g., errors involving corrupted USB drive file systems,
           // surface as unexpected errors.
-          await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
+          void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
             message: 'Falling back to full export...',
             errorDetails: extractErrorMessage(error),
           });
@@ -102,7 +102,7 @@ export async function exportCastVoteRecordsToUsbDrive({
   }
 
   if (exportResult.isErr()) {
-    await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
+    void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
       disposition: 'failure',
       message:
         mode === 'polls_closing'
@@ -111,7 +111,7 @@ export async function exportCastVoteRecordsToUsbDrive({
       errorDetails: JSON.stringify(exportResult.err()),
     });
   } else {
-    await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
+    void logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsComplete, {
       disposition: 'success',
       message:
         mode === 'polls_closing'

--- a/apps/scan/backend/polls/polls.test.ts
+++ b/apps/scan/backend/polls/polls.test.ts
@@ -3,12 +3,12 @@ import { err } from '@vx/libs/basics/result';
 import { openPolls } from './polls';
 import { Store } from '../store/store';
 
-test('opening polls fails if ballots have already been scanned', async () => {
+test('opening polls fails if ballots have already been scanned', () => {
   const logger = mockLogger();
   const store = Store.memoryStore();
   jest.spyOn(store, 'getBallotsCounted').mockReturnValue(1);
 
-  const openPollsResult = await openPolls({
+  const openPollsResult = openPolls({
     store,
     logger,
   });

--- a/apps/scan/backend/polls/polls.ts
+++ b/apps/scan/backend/polls/polls.ts
@@ -9,13 +9,13 @@ import { getCurrentTime } from '../time/get_current_time';
 
 export type OpenPollsResult = Result<void, 'ballots-already-scanned'>;
 
-export async function openPolls({
+export function openPolls({
   store,
   logger,
 }: {
   store: Store;
   logger: Logger;
-}): Promise<OpenPollsResult> {
+}): OpenPollsResult {
   const previousPollsState = store.getPollsState();
   assert(previousPollsState === 'polls_closed_initial');
 
@@ -96,13 +96,13 @@ export async function closePolls({
   }
 }
 
-export async function pauseVoting({
+export function pauseVoting({
   store,
   logger,
 }: {
   store: Store;
   logger: Logger;
-}): Promise<void> {
+}): void {
   const previousPollsState = store.getPollsState();
   assert(previousPollsState === 'polls_open');
 
@@ -122,13 +122,13 @@ export async function pauseVoting({
   });
 }
 
-export async function resumeVoting({
+export function resumeVoting({
   store,
   logger,
 }: {
   store: Store;
   logger: Logger;
-}): Promise<void> {
+}): void {
   const previousPollsState = store.getPollsState();
   assert(previousPollsState === 'polls_paused');
 
@@ -146,13 +146,13 @@ export async function resumeVoting({
   });
 }
 
-export async function resetPollsToPaused({
+export function resetPollsToPaused({
   store,
   logger,
 }: {
   store: Store;
   logger: Logger;
-}): Promise<void> {
+}): void {
   const previousPollsState = store.getPollsState();
   assert(previousPollsState === 'polls_closed_final');
   store.transitionPolls({ type: 'pause_voting', time: getCurrentTime() });

--- a/apps/scan/backend/polls/polls.ts
+++ b/apps/scan/backend/polls/polls.ts
@@ -23,7 +23,7 @@ export async function openPolls({
   // with VVSG 2.0 1.1.3-B, even though it should be an impossible app state.
   const sheetCount = store.getBallotsCounted();
   if (sheetCount > 0) {
-    await logger.logAsCurrentRole(LogEventId.PollsOpened, {
+    void logger.logAsCurrentRole(LogEventId.PollsOpened, {
       disposition: 'failure',
       message:
         'User prevented from opening polls because ballots have already been scanned.',
@@ -33,13 +33,13 @@ export async function openPolls({
   }
 
   store.transitionPolls({ type: 'open_polls', time: getCurrentTime() });
-  await logger.logAsCurrentRole(LogEventId.PollsOpened, {
+  void logger.logAsCurrentRole(LogEventId.PollsOpened, {
     disposition: 'success',
     message: 'User opened the polls.',
   });
 
   const batchId = store.addBatch();
-  await logger.log(LogEventId.ScannerBatchStarted, 'system', {
+  void logger.log(LogEventId.ScannerBatchStarted, 'system', {
     disposition: 'success',
     message: 'New scanning batch started on polls opened.',
     batchId,
@@ -65,7 +65,7 @@ export async function closePolls({
   );
 
   store.transitionPolls({ type: 'close_polls', time: getCurrentTime() });
-  await logger.logAsCurrentRole(LogEventId.PollsClosed, {
+  void logger.logAsCurrentRole(LogEventId.PollsClosed, {
     disposition: 'success',
     message: 'User closed the polls.',
   });
@@ -74,7 +74,7 @@ export async function closePolls({
     const ongoingBatchId = store.getOngoingBatchId();
     assert(ongoingBatchId !== undefined);
     store.finishBatch({ batchId: ongoingBatchId });
-    await logger.log(LogEventId.ScannerBatchEnded, 'system', {
+    void logger.log(LogEventId.ScannerBatchEnded, 'system', {
       disposition: 'success',
       message: 'Current scanning batch finished on polls closed.',
       batchId: ongoingBatchId,
@@ -107,7 +107,7 @@ export async function pauseVoting({
   assert(previousPollsState === 'polls_open');
 
   store.transitionPolls({ type: 'pause_voting', time: getCurrentTime() });
-  await logger.logAsCurrentRole(LogEventId.VotingPaused, {
+  void logger.logAsCurrentRole(LogEventId.VotingPaused, {
     disposition: 'success',
     message: 'User paused voting.',
   });
@@ -115,7 +115,7 @@ export async function pauseVoting({
   const ongoingBatchId = store.getOngoingBatchId();
   assert(ongoingBatchId !== undefined);
   store.finishBatch({ batchId: ongoingBatchId });
-  await logger.log(LogEventId.ScannerBatchEnded, 'system', {
+  void logger.log(LogEventId.ScannerBatchEnded, 'system', {
     disposition: 'success',
     message: 'Current scanning batch finished on voting paused.',
     batchId: ongoingBatchId,
@@ -133,13 +133,13 @@ export async function resumeVoting({
   assert(previousPollsState === 'polls_paused');
 
   store.transitionPolls({ type: 'resume_voting', time: getCurrentTime() });
-  await logger.logAsCurrentRole(LogEventId.VotingResumed, {
+  void logger.logAsCurrentRole(LogEventId.VotingResumed, {
     disposition: 'success',
     message: 'User resumed voting.',
   });
 
   const batchId = store.addBatch();
-  await logger.log(LogEventId.ScannerBatchStarted, 'system', {
+  void logger.log(LogEventId.ScannerBatchStarted, 'system', {
     disposition: 'success',
     message: 'New scanning batch started on voting resumed.',
     batchId,
@@ -156,7 +156,7 @@ export async function resetPollsToPaused({
   const previousPollsState = store.getPollsState();
   assert(previousPollsState === 'polls_closed_final');
   store.transitionPolls({ type: 'pause_voting', time: getCurrentTime() });
-  await logger.logAsCurrentRole(LogEventId.ResetPollsToPaused, {
+  void logger.logAsCurrentRole(LogEventId.ResetPollsToPaused, {
     disposition: 'success',
     message: 'User reset the polls to paused.',
   });

--- a/apps/scan/backend/printing/readiness_report.ts
+++ b/apps/scan/backend/printing/readiness_report.ts
@@ -71,12 +71,12 @@ export async function saveReadinessReport({
   );
 
   if (exportFileResult.isOk()) {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `User saved the equipment readiness report to a USB drive.`,
       disposition: 'success',
     });
   } else {
-    await logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
+    void logger.logAsCurrentRole(LogEventId.ReadinessReportSaved, {
       message: `Error while attempting to save the equipment readiness report to a USB drive: ${
         exportFileResult.err().message
       }`,

--- a/apps/scan/backend/scanners/custom/custom_app_scan_jam.test.ts
+++ b/apps/scan/backend/scanners/custom/custom_app_scan_jam.test.ts
@@ -44,97 +44,91 @@ beforeEach(() => {
 });
 
 test('jam on scan', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      mockScanner.scan.mockImplementation(() => {
-        mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
-        // Returns an intentionally broken value to trigger a reconnect.
-        return Promise.resolve(ok()) as ReturnType<typeof mockScanner.scan>;
-      });
+    mockScanner.scan.mockImplementation(() => {
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
+      // Returns an intentionally broken value to trigger a reconnect.
+      return Promise.resolve(ok()) as ReturnType<typeof mockScanner.scan>;
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
 
-      await waitForStatus(apiClient, {
-        state: 'recovering_from_error',
-        error: 'client_error',
-      });
+    await waitForStatus(api, {
+      state: 'recovering_from_error',
+      error: 'client_error',
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-      clock.increment(delays.DELAY_RECONNECT_ON_UNEXPECTED_ERROR);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+    clock.increment(delays.DELAY_RECONNECT_ON_UNEXPECTED_ERROR);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });
 
 test('jam on accept', async () => {
   const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { testMode: true });
 
-      simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
-      await waitForStatus(apiClient, {
-        state: 'accepting',
-        interpretation,
-      });
-      clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
-      // The paper can't get permanently jammed on accept - it just stays held in
-      // the back and we can reject at that point
-      await waitForStatus(apiClient, {
-        state: 'rejecting',
-        interpretation,
-        error: 'paper_in_back_after_accept',
-      });
+    simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
+    await waitForStatus(api, {
+      state: 'accepting',
+      interpretation,
+    });
+    clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
+    // The paper can't get permanently jammed on accept - it just stays held in
+    // the back and we can reject at that point
+    await waitForStatus(api, {
+      state: 'rejecting',
+      interpretation,
+      error: 'paper_in_back_after_accept',
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, {
-        state: 'rejected',
-        error: 'paper_in_back_after_accept',
-        interpretation,
-      });
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, {
+      state: 'rejected',
+      error: 'paper_in_back_after_accept',
+      interpretation,
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });
 
 test('jam on return', async () => {
   const interpretation = needsReviewInterpretation;
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
-        electionPackage:
-          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(
-            {
-              ...DEFAULT_SYSTEM_SETTINGS,
-              precinctScanAdjudicationReasons: [AdjudicationReason.BlankBallot],
-            }
-          ),
-      });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, {
+      electionPackage:
+        electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(
+          {
+            ...DEFAULT_SYSTEM_SETTINGS,
+            precinctScanAdjudicationReasons: [AdjudicationReason.BlankBallot],
+          }
+        ),
+    });
 
-      simulateScan(mockScanner, await ballotImages.unmarkedHmpb(), clock);
-      await waitForStatus(apiClient, { state: 'needs_review', interpretation });
+    simulateScan(mockScanner, await ballotImages.unmarkedHmpb(), clock);
+    await waitForStatus(api, { state: 'needs_review', interpretation });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
-      await apiClient.returnBallot();
-      await waitForStatus(apiClient, {
-        state: 'jammed',
-        interpretation,
-      });
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
+    api.returnBallot();
+    await waitForStatus(api, {
+      state: 'jammed',
+      interpretation,
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });
 
 test('jam on reject', async () => {
@@ -142,25 +136,23 @@ test('jam on reject', async () => {
     type: 'InvalidSheet',
     reason: 'invalid_ballot_hash',
   };
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      simulateScan(mockScanner, await ballotImages.wrongElection(), clock);
-      await waitForStatus(apiClient, {
-        state: 'rejecting',
-        interpretation,
-      });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, {
-        state: 'jammed',
-        interpretation,
-      });
+    simulateScan(mockScanner, await ballotImages.wrongElection(), clock);
+    await waitForStatus(api, {
+      state: 'rejecting',
+      interpretation,
+    });
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, {
+      state: 'jammed',
+      interpretation,
+    });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+    clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });

--- a/apps/scan/backend/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/scanners/custom/state_machine.ts
@@ -1149,7 +1149,7 @@ function setupLogging(
     .onEvent(async (event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
-      await logger.log(
+      void logger.log(
         LogEventId.ScannerEvent,
         'system',
         { message: `Event: ${event.type}` },
@@ -1189,7 +1189,7 @@ function setupLogging(
         ]);
 
       if (changed.length === 0) return;
-      await logger.log(
+      void logger.log(
         LogEventId.ScannerStateChanged,
         'system',
         {
@@ -1204,7 +1204,7 @@ function setupLogging(
     })
     .onTransition(async (state) => {
       if (!state.changed) return;
-      await logger.log(
+      void logger.log(
         LogEventId.ScannerStateChanged,
         'system',
         {

--- a/apps/scan/backend/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/scanners/custom/state_machine.ts
@@ -1146,7 +1146,7 @@ function setupLogging(
   logger: Logger
 ) {
   machineService
-    .onEvent(async (event) => {
+    .onEvent((event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
       void logger.log(
@@ -1156,7 +1156,7 @@ function setupLogging(
         (logLine: LogLine) => debugEvents(logLine.message)
       );
     })
-    .onChange(async (context, previousContext) => {
+    .onChange((context, previousContext) => {
       if (!previousContext) return;
       const changed = Object.entries(context)
         .filter(
@@ -1202,7 +1202,7 @@ function setupLogging(
         () => debug('Context updated: %o', Object.fromEntries(changed))
       );
     })
-    .onTransition(async (state) => {
+    .onTransition((state) => {
       if (!state.changed) return;
       void logger.log(
         LogEventId.ScannerStateChanged,

--- a/apps/scan/backend/scanners/pdi/pdi_app_double_feed_calibration.test.ts
+++ b/apps/scan/backend/scanners/pdi/pdi_app_double_feed_calibration.test.ts
@@ -32,188 +32,178 @@ beforeEach(() => {
 });
 
 test('calibrate double feed detection', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      // Insert election manager card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
+    // Insert election manager card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
 
-      // Scanning should be paused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
+    // Scanning should be paused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
 
-      // Initiate double feed calibration
-      await apiClient.beginDoubleFeedCalibration();
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.double_sheet',
-      });
-      expect(
-        mockScanner.client.calibrateDoubleFeedDetection
-      ).toHaveBeenLastCalledWith('double');
+    // Initiate double feed calibration
+    api.beginDoubleFeedCalibration();
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.double_sheet',
+    });
+    expect(
+      mockScanner.client.calibrateDoubleFeedDetection
+    ).toHaveBeenLastCalledWith('double');
 
-      // Simulate insert of double sheet
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.single_sheet',
-      });
-      expect(
-        mockScanner.client.calibrateDoubleFeedDetection
-      ).toHaveBeenLastCalledWith('single');
+    // Simulate insert of double sheet
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.single_sheet',
+    });
+    expect(
+      mockScanner.client.calibrateDoubleFeedDetection
+    ).toHaveBeenLastCalledWith('single');
 
-      // Simulate insert of single sheet
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.done',
-      });
+    // Simulate insert of single sheet
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.done',
+    });
 
-      // End double feed calibration
-      await apiClient.endDoubleFeedCalibration();
-      await waitForStatus(apiClient, { state: 'paused' });
-    }
-  );
+    // End double feed calibration
+    api.endDoubleFeedCalibration();
+    await waitForStatus(api, { state: 'paused' });
+  });
 });
 
 test('calibration time out waiting for double sheet', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      // Insert election manager card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
+    // Insert election manager card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
 
-      // Scanning should be paused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
+    // Scanning should be paused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
 
-      // Initiate double feed calibration
-      await apiClient.beginDoubleFeedCalibration();
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.double_sheet',
-      });
+    // Initiate double feed calibration
+    api.beginDoubleFeedCalibration();
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.double_sheet',
+    });
 
-      // Simulate PDI scanner timeout
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationTimedOut' });
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.done',
-        error: 'double_feed_calibration_timed_out',
-      });
+    // Simulate PDI scanner timeout
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationTimedOut' });
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.done',
+      error: 'double_feed_calibration_timed_out',
+    });
 
-      // End double feed calibration
-      await apiClient.endDoubleFeedCalibration();
-      await waitForStatus(apiClient, { state: 'paused' });
-    }
-  );
+    // End double feed calibration
+    api.endDoubleFeedCalibration();
+    await waitForStatus(api, { state: 'paused' });
+  });
 });
 
 test('calibration time out waiting for single sheet', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      // Insert election manager card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
+    // Insert election manager card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
 
-      // Scanning should be paused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
+    // Scanning should be paused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
 
-      // Initiate double feed calibration
-      await apiClient.beginDoubleFeedCalibration();
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.double_sheet',
-      });
+    // Initiate double feed calibration
+    api.beginDoubleFeedCalibration();
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.double_sheet',
+    });
 
-      // Simulate insert of double sheet
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.single_sheet',
-      });
+    // Simulate insert of double sheet
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.single_sheet',
+    });
 
-      // Simulate PDI scanner timeout
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationTimedOut' });
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.done',
-        error: 'double_feed_calibration_timed_out',
-      });
+    // Simulate PDI scanner timeout
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationTimedOut' });
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.done',
+      error: 'double_feed_calibration_timed_out',
+    });
 
-      // End double feed calibration
-      await apiClient.endDoubleFeedCalibration();
-      await waitForStatus(apiClient, { state: 'paused' });
-    }
-  );
+    // End double feed calibration
+    api.endDoubleFeedCalibration();
+    await waitForStatus(api, { state: 'paused' });
+  });
 });
 
 test('error with calibration command for double sheet', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
 
-      // We haven't seen this happen in practice, but we cover it just in case
-      mockScanner.client.calibrateDoubleFeedDetection.mockRejectedValue(
-        new Error('some error')
-      );
-      const deferredConnect = deferred<Result<void, ScannerError>>();
-      mockScanner.client.connect.mockResolvedValue(deferredConnect.promise);
+    // We haven't seen this happen in practice, but we cover it just in case
+    mockScanner.client.calibrateDoubleFeedDetection.mockRejectedValue(
+      new Error('some error')
+    );
+    const deferredConnect = deferred<Result<void, ScannerError>>();
+    mockScanner.client.connect.mockResolvedValue(deferredConnect.promise);
 
-      await apiClient.beginDoubleFeedCalibration();
-      await waitForStatus(apiClient, {
-        state: 'unrecoverable_error',
-      });
-    }
-  );
+    api.beginDoubleFeedCalibration();
+    await waitForStatus(api, {
+      state: 'unrecoverable_error',
+    });
+  });
 });
 
 test('error with calibration command for single sheet', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
 
-      // Initiate double feed calibration
-      await apiClient.beginDoubleFeedCalibration();
-      await waitForStatus(apiClient, {
-        state: 'calibrating_double_feed_detection.double_sheet',
-      });
+    // Initiate double feed calibration
+    api.beginDoubleFeedCalibration();
+    await waitForStatus(api, {
+      state: 'calibrating_double_feed_detection.double_sheet',
+    });
 
-      mockScanner.client.calibrateDoubleFeedDetection.mockRejectedValue(
-        new Error('some error')
-      );
-      const deferredConnect = deferred<Result<void, ScannerError>>();
-      mockScanner.client.connect.mockResolvedValue(deferredConnect.promise);
+    mockScanner.client.calibrateDoubleFeedDetection.mockRejectedValue(
+      new Error('some error')
+    );
+    const deferredConnect = deferred<Result<void, ScannerError>>();
+    mockScanner.client.connect.mockResolvedValue(deferredConnect.promise);
 
-      // Simulate insert of double sheet
-      mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
-      await waitForStatus(apiClient, {
-        state: 'unrecoverable_error',
-      });
-    }
-  );
+    // Simulate insert of double sheet
+    mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
+    await waitForStatus(api, {
+      state: 'unrecoverable_error',
+    });
+  });
 });

--- a/apps/scan/backend/scanners/pdi/pdi_app_scan_jam.test.ts
+++ b/apps/scan/backend/scanners/pdi/pdi_app_scan_jam.test.ts
@@ -44,223 +44,191 @@ beforeEach(() => {
 });
 
 test('jam while scanning', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
 
-      mockScanner.emitEvent({ event: 'scanStart' });
-      await expectStatus(apiClient, { state: 'scanning' });
+    mockScanner.emitEvent({ event: 'scanStart' });
+    expectStatus(api, { state: 'scanning' });
 
-      mockScanner.setScannerStatus(mockStatus.jammed);
-      const deferredEject = deferred<Result<void, ScannerError>>();
-      mockScanner.client.ejectDocument.mockReturnValueOnce(
-        deferredEject.promise
-      );
-      mockScanner.emitEvent({ event: 'error', code: 'scanFailed' });
-      await waitForStatus(apiClient, {
-        state: 'rejecting',
-        error: 'scanning_failed',
-      });
-      deferredEject.resolve(ok());
-      await waitForStatus(apiClient, {
-        state: 'jammed',
-        error: 'scanning_failed',
-      });
+    mockScanner.setScannerStatus(mockStatus.jammed);
+    const deferredEject = deferred<Result<void, ScannerError>>();
+    mockScanner.client.ejectDocument.mockReturnValueOnce(deferredEject.promise);
+    mockScanner.emitEvent({ event: 'error', code: 'scanFailed' });
+    await waitForStatus(api, {
+      state: 'rejecting',
+      error: 'scanning_failed',
+    });
+    deferredEject.resolve(ok());
+    await waitForStatus(api, {
+      state: 'jammed',
+      error: 'scanning_failed',
+    });
 
-      mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
+    clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });
 
 test('jam while accepting', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
-        electionPackage:
-          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
-      });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, {
+      electionPackage:
+        electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
+    });
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
 
-      await simulateScan(
-        apiClient,
-        mockScanner,
-        await ballotImages.completeHmpb()
-      );
+    simulateScan(api, mockScanner, await ballotImages.completeHmpb());
 
-      const interpretation: SheetInterpretation = { type: 'ValidSheet' };
-      const deferredAccept = deferred<Result<void, ScannerError>>();
-      mockScanner.client.ejectDocument.mockReturnValueOnce(
-        deferredAccept.promise
-      );
-      await waitForStatus(apiClient, {
-        state: 'accepting',
-        interpretation,
-      });
+    const interpretation: SheetInterpretation = { type: 'ValidSheet' };
+    const deferredAccept = deferred<Result<void, ScannerError>>();
+    mockScanner.client.ejectDocument.mockReturnValueOnce(
+      deferredAccept.promise
+    );
+    await waitForStatus(api, {
+      state: 'accepting',
+      interpretation,
+    });
 
-      mockScanner.setScannerStatus(mockStatus.jammed);
-      deferredAccept.resolve(ok());
+    mockScanner.setScannerStatus(mockStatus.jammed);
+    deferredAccept.resolve(ok());
 
-      await waitForStatus(apiClient, {
-        state: 'accepted',
-        interpretation,
-        ballotsCounted: 1,
-      });
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
-      await waitForStatus(apiClient, {
-        state: 'jammed',
-        error: 'outfeed_blocked',
-        ballotsCounted: 1,
-      });
+    await waitForStatus(api, {
+      state: 'accepted',
+      interpretation,
+      ballotsCounted: 1,
+    });
+    clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+    await waitForStatus(api, {
+      state: 'jammed',
+      error: 'outfeed_blocked',
+      ballotsCounted: 1,
+    });
 
-      mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper', ballotsCounted: 1 });
-    }
-  );
+    mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
+    clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper', ballotsCounted: 1 });
+  });
 });
 
 // If the ballot gets blocked from being ejected on accept, we often don't get a
 // jam status, but hit the timeout case instead.
 test('timeout while accepting', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
-        electionPackage:
-          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
-      });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, {
+      electionPackage:
+        electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
+    });
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
 
-      await simulateScan(
-        apiClient,
-        mockScanner,
-        await ballotImages.completeHmpb()
-      );
+    simulateScan(api, mockScanner, await ballotImages.completeHmpb());
 
-      const interpretation: SheetInterpretation = { type: 'ValidSheet' };
-      await waitForStatus(apiClient, {
-        state: 'accepting',
-        interpretation,
-      });
+    const interpretation: SheetInterpretation = { type: 'ValidSheet' };
+    await waitForStatus(api, {
+      state: 'accepting',
+      interpretation,
+    });
 
-      clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
-      await waitForStatus(apiClient, {
-        state: 'accepted',
-        interpretation,
-        ballotsCounted: 1,
-      });
+    clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
+    await waitForStatus(api, {
+      state: 'accepted',
+      interpretation,
+      ballotsCounted: 1,
+    });
 
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
-      await waitForStatus(apiClient, {
-        state: 'jammed',
-        error: 'outfeed_blocked',
-        ballotsCounted: 1,
-      });
+    clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+    await waitForStatus(api, {
+      state: 'jammed',
+      error: 'outfeed_blocked',
+      ballotsCounted: 1,
+    });
 
-      mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper', ballotsCounted: 1 });
-    }
-  );
+    mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
+    clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper', ballotsCounted: 1 });
+  });
 });
 
 test('jam while rejecting', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
 
-      await simulateScan(
-        apiClient,
-        mockScanner,
-        await ballotImages.wrongElectionBmd()
-      );
+    simulateScan(api, mockScanner, await ballotImages.wrongElectionBmd());
 
-      const interpretation: SheetInterpretation = {
-        type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
-      };
-      const deferredEject = deferred<Result<void, ScannerError>>();
-      mockScanner.client.ejectDocument.mockReturnValueOnce(
-        deferredEject.promise
-      );
-      await waitForStatus(apiClient, {
-        state: 'rejecting',
-        interpretation,
-      });
+    const interpretation: SheetInterpretation = {
+      type: 'InvalidSheet',
+      reason: 'invalid_ballot_hash',
+    };
+    const deferredEject = deferred<Result<void, ScannerError>>();
+    mockScanner.client.ejectDocument.mockReturnValueOnce(deferredEject.promise);
+    await waitForStatus(api, {
+      state: 'rejecting',
+      interpretation,
+    });
 
-      mockScanner.setScannerStatus(mockStatus.jammed);
-      deferredEject.resolve(ok());
-      await waitForStatus(apiClient, { state: 'jammed', interpretation });
+    mockScanner.setScannerStatus(mockStatus.jammed);
+    deferredEject.resolve(ok());
+    await waitForStatus(api, { state: 'jammed', interpretation });
 
-      mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
+    clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });
 
 test('jam while returning', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
-        electionPackage:
-          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(
-            {
-              ...DEFAULT_SYSTEM_SETTINGS,
-              precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
-            }
-          ),
-      });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, {
+      electionPackage:
+        electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(
+          {
+            ...DEFAULT_SYSTEM_SETTINGS,
+            precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
+          }
+        ),
+    });
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
 
-      await simulateScan(
-        apiClient,
-        mockScanner,
-        await ballotImages.overvoteHmpb()
-      );
+    simulateScan(api, mockScanner, await ballotImages.overvoteHmpb());
 
-      const interpretation: SheetInterpretation = {
-        type: 'NeedsReviewSheet',
-        reasons: [
-          expect.objectContaining(
-            typedAs<Partial<AdjudicationReasonInfo>>({
-              type: AdjudicationReason.Overvote,
-            })
-          ),
-        ],
-      };
-      await waitForStatus(apiClient, {
-        state: 'needs_review',
-        interpretation,
-      });
+    const interpretation: SheetInterpretation = {
+      type: 'NeedsReviewSheet',
+      reasons: [
+        expect.objectContaining(
+          typedAs<Partial<AdjudicationReasonInfo>>({
+            type: AdjudicationReason.Overvote,
+          })
+        ),
+      ],
+    };
+    await waitForStatus(api, {
+      state: 'needs_review',
+      interpretation,
+    });
 
-      const deferredEject = deferred<Result<void, ScannerError>>();
-      mockScanner.client.ejectDocument.mockReturnValueOnce(
-        deferredEject.promise
-      );
-      await apiClient.returnBallot();
-      await expectStatus(apiClient, { state: 'returning', interpretation });
+    const deferredEject = deferred<Result<void, ScannerError>>();
+    mockScanner.client.ejectDocument.mockReturnValueOnce(deferredEject.promise);
+    api.returnBallot();
+    expectStatus(api, { state: 'returning', interpretation });
 
-      mockScanner.setScannerStatus(mockStatus.jammed);
-      deferredEject.resolve(ok());
-      await waitForStatus(apiClient, { state: 'jammed', interpretation });
+    mockScanner.setScannerStatus(mockStatus.jammed);
+    deferredEject.resolve(ok());
+    await waitForStatus(api, { state: 'jammed', interpretation });
 
-      mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-    }
-  );
+    mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
+    clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+  });
 });

--- a/apps/scan/backend/scanners/pdi/pdi_app_scan_paused.test.ts
+++ b/apps/scan/backend/scanners/pdi/pdi_app_scan_paused.test.ts
@@ -30,71 +30,67 @@ beforeEach(() => {
 });
 
 test('if election manager card inserted, scanning paused', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive);
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive);
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+    expect(mockScanner.client.enableScanning).toHaveBeenCalled();
 
-      // Insert election manager card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
+    // Insert election manager card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockElectionManagerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
 
-      // Scanning should be paused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
-      expect(mockScanner.client.disableScanning).toHaveBeenCalled();
+    // Scanning should be paused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
+    expect(mockScanner.client.disableScanning).toHaveBeenCalled();
 
-      // Remove the card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_out',
-        reason: 'no_card',
-      });
+    // Remove the card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_out',
+      reason: 'no_card',
+    });
 
-      // Scanning should be unpaused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
-    }
-  );
+    // Scanning should be unpaused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+    expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+  });
 });
 
 test('if poll worker card inserted, scanning paused', async () => {
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+  await withApp(async ({ api, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    await configureApp(api, mockAuth, mockUsbDrive, { testMode: true });
 
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+    expect(mockScanner.client.enableScanning).toHaveBeenCalled();
 
-      // Insert poll worker card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_in',
-        user: mockPollWorkerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      });
+    // Insert poll worker card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockPollWorkerUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
 
-      // Scanning should be paused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'paused' });
-      expect(mockScanner.client.disableScanning).toHaveBeenCalled();
+    // Scanning should be paused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'paused' });
+    expect(mockScanner.client.disableScanning).toHaveBeenCalled();
 
-      // Remove the card
-      mockOf(mockAuth.getAuthStatus).mockResolvedValue({
-        status: 'logged_out',
-        reason: 'no_card',
-      });
+    // Remove the card
+    mockOf(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_out',
+      reason: 'no_card',
+    });
 
-      // Scanning should be unpaused
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
-    }
-  );
+    // Scanning should be unpaused
+    clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+    await waitForStatus(api, { state: 'no_paper' });
+    expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+  });
 });

--- a/apps/scan/backend/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/scanners/pdi/state_machine.ts
@@ -1150,7 +1150,7 @@ function setupLogging(
       const eventString = JSON.stringify(event, cleanLogData);
       if (isEventUserAction(event)) {
         // This event was triggered by a user so we should log as a current user role, falling back to 'cardless_voter' if there is no one authenticated.
-        await logger.logAsCurrentRole(
+        void logger.logAsCurrentRole(
           LogEventId.ScannerEvent,
           { message: `Event: ${event.type}`, eventObject: eventString },
           /* istanbul ignore next */
@@ -1159,7 +1159,7 @@ function setupLogging(
         );
       } else {
         // Non-user driven events can be logged with a user of 'system'
-        await logger.log(
+        void logger.log(
           LogEventId.ScannerEvent,
           'system',
           { message: `Event: ${event.type}`, eventObject: eventString },
@@ -1178,7 +1178,7 @@ function setupLogging(
         Object.fromEntries(changed),
         cleanLogData
       );
-      await logger.log(
+      void logger.log(
         LogEventId.ScannerStateChanged,
         'system',
         {
@@ -1190,7 +1190,7 @@ function setupLogging(
     })
     .onTransition(async (state) => {
       if (!state.changed) return;
-      await logger.log(
+      void logger.log(
         LogEventId.ScannerStateChanged,
         'system',
         {

--- a/apps/scan/backend/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/scanners/pdi/state_machine.ts
@@ -1146,7 +1146,7 @@ function setupLogging(
   logger: Logger
 ) {
   machineService
-    .onEvent(async (event) => {
+    .onEvent((event) => {
       const eventString = JSON.stringify(event, cleanLogData);
       if (isEventUserAction(event)) {
         // This event was triggered by a user so we should log as a current user role, falling back to 'cardless_voter' if there is no one authenticated.
@@ -1167,7 +1167,7 @@ function setupLogging(
         );
       }
     })
-    .onChange(async (context, previousContext) => {
+    .onChange((context, previousContext) => {
       /* istanbul ignore next */
       if (!previousContext) return;
       const changed = Object.entries(context).filter(
@@ -1188,7 +1188,7 @@ function setupLogging(
         () => debug(`Context updated: ${contextString}`)
       );
     })
-    .onTransition(async (state) => {
+    .onTransition((state) => {
       if (!state.changed) return;
       void logger.log(
         LogEventId.ScannerStateChanged,

--- a/apps/scan/backend/scanners/shared.ts
+++ b/apps/scan/backend/scanners/shared.ts
@@ -43,7 +43,7 @@ async function exportCastVoteRecordToUsbDriveWithLogging(
   // which ballots were cast
   const operationId = uuid();
 
-  await logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
+  void logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
     message: `Queueing ${acceptedOrRejected} sheet for continuous export to USB drive.`,
     operationId,
   });
@@ -51,7 +51,7 @@ async function exportCastVoteRecordToUsbDriveWithLogging(
   let exportResult: Result<void, ExportCastVoteRecordsToUsbDriveError>;
   try {
     exportResult = await continuousExportMutex.withLock(async () => {
-      await logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
+      void logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
         message: `Exporting cast vote record for ${acceptedOrRejected} sheet to USB drive...`,
         operationId,
       });
@@ -76,7 +76,7 @@ async function exportCastVoteRecordToUsbDriveWithLogging(
     });
     throw error;
   }
-  await logger.log(LogEventId.ExportCastVoteRecordsComplete, 'system', {
+  void logger.log(LogEventId.ExportCastVoteRecordsComplete, 'system', {
     disposition: 'success',
     message: `Successfully exported cast vote record for ${acceptedOrRejected} sheet to USB drive.`,
     operationId,

--- a/apps/scan/backend/server/server.ts
+++ b/apps/scan/backend/server/server.ts
@@ -46,12 +46,12 @@ export function start({
   });
 
   app.listen(PORT, async () => {
-    await logger.log(LogEventId.ApplicationStartup, 'system', {
+    void logger.log(LogEventId.ApplicationStartup, 'system', {
       message: `VxScan backend running at http://localhost:${PORT}/`,
       disposition: 'success',
     });
 
-    await logger.log(LogEventId.WorkspaceConfigurationMessage, 'system', {
+    void logger.log(LogEventId.WorkspaceConfigurationMessage, 'system', {
       message: `Scanning ballots into ${workspace.ballotImagesPath}`,
     });
   });

--- a/apps/scan/backend/server/server.ts
+++ b/apps/scan/backend/server/server.ts
@@ -45,7 +45,7 @@ export function start({
     logger,
   });
 
-  app.listen(PORT, async () => {
+  app.listen(PORT, () => {
     void logger.log(LogEventId.ApplicationStartup, 'system', {
       message: `VxScan backend running at http://localhost:${PORT}/`,
       disposition: 'success',

--- a/apps/scan/backend/workspace/workspace.ts
+++ b/apps/scan/backend/workspace/workspace.ts
@@ -1,6 +1,6 @@
 import { emptyDirSync, ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'node:path';
-import { Mutex } from '@vx/libs/utils/src';
+import { isIntegrationTest, Mutex } from '@vx/libs/utils/src';
 import {
   type DiskSpaceSummary,
   initializeGetWorkspaceDiskSpaceSummary,
@@ -74,7 +74,11 @@ export function createWorkspace(
   ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
-  const store = options.store || Store.fileStore(dbPath, logger);
+  const store = options.store
+    ? options.store
+    : process.env.NODE_ENV === 'test' || isIntegrationTest()
+    ? Store.memoryStore()
+    : Store.fileStore(dbPath, logger);
 
   // check disk space on startup to detect a new maximum available disk space
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(

--- a/libs/auth/dipped-cards/dipped_smart_card_auth.test.ts
+++ b/libs/auth/dipped-cards/dipped_smart_card_auth.test.ts
@@ -383,7 +383,7 @@ test.each<{
       }
     );
 
-    await auth.logOut(defaultMachineState);
+    auth.logOut(defaultMachineState);
     expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
       status: 'logged_out',
       reason: 'machine_locked',

--- a/libs/auth/dipped-cards/dipped_smart_card_auth.ts
+++ b/libs/auth/dipped-cards/dipped_smart_card_auth.ts
@@ -84,7 +84,7 @@ function cardStatusToProgrammableCard(
  * Given a previous auth status and a new auth status following an auth status transition, infers
  * and logs the relevant auth event, if any
  */
-async function logAuthEventIfNecessary(
+function logAuthEventIfNecessary(
   previousAuthStatus: DippedSmartCardAuthTypes.AuthStatus,
   newAuthStatus: DippedSmartCardAuthTypes.AuthStatus,
   logger: BaseLogger
@@ -234,14 +234,14 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     } catch (error) {
       checkPinResponse = { response: 'error', error };
     }
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'check_pin',
       checkPinResponse,
     });
   }
 
-  async logOut(machineState: DippedSmartCardAuthMachineState): Promise<void> {
-    await this.updateAuthStatus(machineState, { type: 'log_out' });
+  logOut(machineState: DippedSmartCardAuthMachineState): void {
+    this.updateAuthStatus(machineState, { type: 'log_out' });
   }
 
   async updateSessionExpiry(
@@ -249,7 +249,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     input: { sessionExpiresAt: Date }
   ): Promise<void> {
     await this.checkCardReaderAndUpdateAuthStatus(machineState);
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'update_session_expiry',
       sessionExpiresAt: input.sessionExpiresAt,
     });
@@ -418,16 +418,16 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     machineState: DippedSmartCardAuthMachineState
   ): Promise<void> {
     const cardStatus = await this.card.getCardStatus();
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'check_card_reader',
       cardStatus,
     });
   }
 
-  private async updateAuthStatus(
+  private updateAuthStatus(
     machineState: DippedSmartCardAuthMachineState,
     action: AuthAction
-  ): Promise<void> {
+  ): void {
     const previousAuthStatus = this.authStatus;
     this.authStatus = this.determineNewAuthStatus(machineState, action);
     void logAuthEventIfNecessary(

--- a/libs/auth/dipped-cards/dipped_smart_card_auth.ts
+++ b/libs/auth/dipped-cards/dipped_smart_card_auth.ts
@@ -96,7 +96,7 @@ async function logAuthEventIfNecessary(
         newAuthStatus.status === 'logged_out' &&
         newAuthStatus.reason !== 'machine_locked'
       ) {
-        await logger.log(
+        void logger.log(
           LogEventId.AuthLogin,
           newAuthStatus.cardUserRole ?? 'unknown',
           {
@@ -111,14 +111,10 @@ async function logAuthEventIfNecessary(
 
     case 'checking_pin': {
       if (newAuthStatus.status === 'logged_out') {
-        await logger.log(
-          LogEventId.AuthPinEntry,
-          previousAuthStatus.user.role,
-          {
-            disposition: LogDispositionStandardTypes.Failure,
-            message: 'User canceled PIN entry.',
-          }
-        );
+        void logger.log(LogEventId.AuthPinEntry, previousAuthStatus.user.role, {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User canceled PIN entry.',
+        });
       } else if (newAuthStatus.status === 'checking_pin') {
         if (
           newAuthStatus.wrongPinEnteredAt &&
@@ -126,7 +122,7 @@ async function logAuthEventIfNecessary(
             previousAuthStatus.wrongPinEnteredAt
         ) {
           if (newAuthStatus.lockedOutUntil) {
-            await logger.log(
+            void logger.log(
               LogEventId.AuthPinEntryLockout,
               newAuthStatus.user.role,
               {
@@ -136,7 +132,7 @@ async function logAuthEventIfNecessary(
               }
             );
           } else {
-            await logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
+            void logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
               disposition: LogDispositionStandardTypes.Failure,
               message: 'User entered incorrect PIN.',
             });
@@ -145,7 +141,7 @@ async function logAuthEventIfNecessary(
           newAuthStatus.error &&
           newAuthStatus.error.erroredAt !== previousAuthStatus.error?.erroredAt
         ) {
-          await logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
+          void logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
             disposition: LogDispositionStandardTypes.Failure,
             message: `Error checking PIN: ${extractErrorMessage(
               newAuthStatus.error.error
@@ -153,7 +149,7 @@ async function logAuthEventIfNecessary(
           });
         }
       } else if (newAuthStatus.status === 'remove_card') {
-        await logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
+        void logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
           disposition: LogDispositionStandardTypes.Success,
           message: 'User entered correct PIN.',
         });
@@ -163,7 +159,7 @@ async function logAuthEventIfNecessary(
 
     case 'remove_card': {
       if (newAuthStatus.status === 'logged_in') {
-        await logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
+        void logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
           disposition: LogDispositionStandardTypes.Success,
           message: 'User logged in.',
         });
@@ -174,25 +170,17 @@ async function logAuthEventIfNecessary(
     case 'logged_in': {
       if (newAuthStatus.status === 'logged_out') {
         if (newAuthStatus.reason === 'machine_locked_by_session_expiry') {
-          await logger.log(
-            LogEventId.AuthLogout,
-            previousAuthStatus.user.role,
-            {
-              disposition: LogDispositionStandardTypes.Success,
-              message: 'User logged out automatically due to session expiry.',
-              reason: newAuthStatus.reason,
-            }
-          );
+          void logger.log(LogEventId.AuthLogout, previousAuthStatus.user.role, {
+            disposition: LogDispositionStandardTypes.Success,
+            message: 'User logged out automatically due to session expiry.',
+            reason: newAuthStatus.reason,
+          });
         } else {
-          await logger.log(
-            LogEventId.AuthLogout,
-            previousAuthStatus.user.role,
-            {
-              disposition: LogDispositionStandardTypes.Success,
-              message: 'User logged out.',
-              reason: newAuthStatus.reason,
-            }
-          );
+          void logger.log(LogEventId.AuthLogout, previousAuthStatus.user.role, {
+            disposition: LogDispositionStandardTypes.Success,
+            message: 'User logged out.',
+            reason: newAuthStatus.reason,
+          });
         }
       }
       return;
@@ -442,7 +430,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
   ): Promise<void> {
     const previousAuthStatus = this.authStatus;
     this.authStatus = this.determineNewAuthStatus(machineState, action);
-    await logAuthEventIfNecessary(
+    void logAuthEventIfNecessary(
       previousAuthStatus,
       this.authStatus,
       this.logger

--- a/libs/auth/dipped-cards/dipped_smart_card_auth_api.ts
+++ b/libs/auth/dipped-cards/dipped_smart_card_auth_api.ts
@@ -24,7 +24,7 @@ export interface DippedSmartCardAuthApi {
     machineState: DippedSmartCardAuthMachineState,
     input: { pin: string }
   ): Promise<void>;
-  logOut(machineState: DippedSmartCardAuthMachineState): Promise<void>;
+  logOut(machineState: DippedSmartCardAuthMachineState): void;
   updateSessionExpiry(
     machineState: DippedSmartCardAuthMachineState,
     input: { sessionExpiresAt: Date }

--- a/libs/auth/inserted-cards/inserted_smart_card_auth.test.ts
+++ b/libs/auth/inserted-cards/inserted_smart_card_auth.test.ts
@@ -597,7 +597,7 @@ test('Logout through logout method', async () => {
 
   // Because the card is still inserted, we'll automatically transition back to the PIN checking
   // state after logout
-  await auth.logOut(defaultMachineState);
+  auth.logOut(defaultMachineState);
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,

--- a/libs/auth/inserted-cards/inserted_smart_card_auth.ts
+++ b/libs/auth/inserted-cards/inserted_smart_card_auth.ts
@@ -64,7 +64,7 @@ async function logAuthEvent(
         newAuthStatus.status === 'logged_out' &&
         newAuthStatus.reason !== 'no_card'
       ) {
-        await logger.log(
+        void logger.log(
           LogEventId.AuthLogin,
           newAuthStatus.cardUserRole ?? 'unknown',
           {
@@ -74,7 +74,7 @@ async function logAuthEvent(
           }
         );
       } else if (newAuthStatus.status === 'logged_in') {
-        await logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
+        void logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
           disposition: LogDispositionStandardTypes.Success,
           message: 'User logged in.',
         });
@@ -84,14 +84,10 @@ async function logAuthEvent(
 
     case 'checking_pin': {
       if (newAuthStatus.status === 'logged_out') {
-        await logger.log(
-          LogEventId.AuthPinEntry,
-          previousAuthStatus.user.role,
-          {
-            disposition: LogDispositionStandardTypes.Failure,
-            message: 'User canceled PIN entry.',
-          }
-        );
+        void logger.log(LogEventId.AuthPinEntry, previousAuthStatus.user.role, {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User canceled PIN entry.',
+        });
       } else if (newAuthStatus.status === 'checking_pin') {
         if (
           newAuthStatus.wrongPinEnteredAt &&
@@ -99,7 +95,7 @@ async function logAuthEvent(
             newAuthStatus.wrongPinEnteredAt
         ) {
           if (newAuthStatus.lockedOutUntil) {
-            await logger.log(
+            void logger.log(
               LogEventId.AuthPinEntryLockout,
               newAuthStatus.user.role,
               {
@@ -109,7 +105,7 @@ async function logAuthEvent(
               }
             );
           } else {
-            await logger.log(
+            void logger.log(
               LogEventId.AuthPinEntry,
               previousAuthStatus.user.role,
               {
@@ -120,11 +116,11 @@ async function logAuthEvent(
           }
         }
       } else if (newAuthStatus.status === 'logged_in') {
-        await logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
+        void logger.log(LogEventId.AuthPinEntry, newAuthStatus.user.role, {
           disposition: LogDispositionStandardTypes.Success,
           message: 'User entered correct PIN.',
         });
-        await logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
+        void logger.log(LogEventId.AuthLogin, newAuthStatus.user.role, {
           disposition: LogDispositionStandardTypes.Success,
           message: 'User logged in.',
         });
@@ -136,25 +132,17 @@ async function logAuthEvent(
     case 'logged_in': {
       if (newAuthStatus.status === 'logged_out') {
         if (newAuthStatus.reason === 'session_expired') {
-          await logger.log(
-            LogEventId.AuthLogout,
-            previousAuthStatus.user.role,
-            {
-              disposition: LogDispositionStandardTypes.Success,
-              message: 'User logged out automatically due to session expiry.',
-              reason: newAuthStatus.reason,
-            }
-          );
+          void logger.log(LogEventId.AuthLogout, previousAuthStatus.user.role, {
+            disposition: LogDispositionStandardTypes.Success,
+            message: 'User logged out automatically due to session expiry.',
+            reason: newAuthStatus.reason,
+          });
         } else {
-          await logger.log(
-            LogEventId.AuthLogout,
-            previousAuthStatus.user.role,
-            {
-              disposition: LogDispositionStandardTypes.Success,
-              message: 'User logged out.',
-              reason: newAuthStatus.reason,
-            }
-          );
+          void logger.log(LogEventId.AuthLogout, previousAuthStatus.user.role, {
+            disposition: LogDispositionStandardTypes.Success,
+            message: 'User logged out.',
+            reason: newAuthStatus.reason,
+          });
         }
       }
       return;
@@ -373,7 +361,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
   ): Promise<void> {
     const previousAuthStatus = this.authStatus;
     this.authStatus = this.determineNewAuthStatus(machineState, action);
-    await logAuthEvent(previousAuthStatus, this.authStatus, this.logger);
+    void logAuthEvent(previousAuthStatus, this.authStatus, this.logger);
   }
 
   private determineNewAuthStatus(

--- a/libs/auth/inserted-cards/inserted_smart_card_auth.ts
+++ b/libs/auth/inserted-cards/inserted_smart_card_auth.ts
@@ -52,7 +52,7 @@ type AuthAction =
  * Given a previous auth status and a new auth status following an auth status transition, infers
  * and logs the relevant auth event, if any
  */
-async function logAuthEvent(
+function logAuthEvent(
   previousAuthStatus: InsertedSmartCardAuthTypes.AuthStatus,
   newAuthStatus: InsertedSmartCardAuthTypes.AuthStatus,
   logger: BaseLogger
@@ -230,14 +230,14 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       });
       checkPinResponse = { response: 'error' };
     }
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'check_pin',
       checkPinResponse,
     });
   }
 
-  async logOut(machineState: InsertedSmartCardAuthMachineState): Promise<void> {
-    await this.updateAuthStatus(machineState, { type: 'log_out' });
+  logOut(machineState: InsertedSmartCardAuthMachineState): void {
+    this.updateAuthStatus(machineState, { type: 'log_out' });
   }
 
   async updateSessionExpiry(
@@ -245,7 +245,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
     input: { sessionExpiresAt: Date }
   ): Promise<void> {
     await this.checkCardReaderAndUpdateAuthStatus(machineState);
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'update_session_expiry',
       sessionExpiresAt: input.sessionExpiresAt,
     });
@@ -349,16 +349,16 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
     machineState: InsertedSmartCardAuthMachineState
   ): Promise<void> {
     const cardStatus = await this.card.getCardStatus();
-    await this.updateAuthStatus(machineState, {
+    this.updateAuthStatus(machineState, {
       type: 'check_card_reader',
       cardStatus,
     });
   }
 
-  private async updateAuthStatus(
+  private updateAuthStatus(
     machineState: InsertedSmartCardAuthMachineState,
     action: AuthAction
-  ): Promise<void> {
+  ): void {
     const previousAuthStatus = this.authStatus;
     this.authStatus = this.determineNewAuthStatus(machineState, action);
     void logAuthEvent(previousAuthStatus, this.authStatus, this.logger);

--- a/libs/auth/inserted-cards/inserted_smart_card_auth_api.ts
+++ b/libs/auth/inserted-cards/inserted_smart_card_auth_api.ts
@@ -28,7 +28,7 @@ export interface InsertedSmartCardAuthApi {
    * smart card auth, this method is still useful for clearing the session and re-requiring PIN
    * entry, e.g. after the inactive session time limit has been hit.
    */
-  logOut(machineState: InsertedSmartCardAuthMachineState): Promise<void>;
+  logOut(machineState: InsertedSmartCardAuthMachineState): void;
   updateSessionExpiry(
     machineState: InsertedSmartCardAuthMachineState,
     input: { sessionExpiresAt: Date }

--- a/libs/backend/diagnostics/disk_space_summary.test.ts
+++ b/libs/backend/diagnostics/disk_space_summary.test.ts
@@ -145,13 +145,12 @@ test('initializeGetWorkspaceDiskSpaceSummary', async () => {
   );
 
   // disk space set up on initialize
-  expect(execFileMock).toHaveBeenCalledWith('df', ['/var', '/tmp', '--total']);
   expect(await getWorkspaceDiskSpaceSummaryFn()).toEqual({
     total: 50,
     used: 0,
     available: 50,
   });
-  expect(execFileMock).toHaveBeenCalledTimes(2);
+  expect(execFileMock).toHaveBeenCalledTimes(1);
 
   mockDiskFreeOutput({
     total: 100,
@@ -163,5 +162,5 @@ test('initializeGetWorkspaceDiskSpaceSummary', async () => {
     used: 10,
     available: 40,
   });
-  expect(execFileMock).toHaveBeenCalledTimes(3);
+  expect(execFileMock).toHaveBeenCalledTimes(2);
 });

--- a/libs/backend/diagnostics/disk_space_summary.ts
+++ b/libs/backend/diagnostics/disk_space_summary.ts
@@ -133,7 +133,5 @@ export function initializeGetWorkspaceDiskSpaceSummary(
   store: UsableDiskSpaceStore,
   workspacePaths: string[]
 ): () => Promise<DiskSpaceSummary> {
-  void getWorkspaceDiskSpaceSummary(store, workspacePaths);
-
   return () => getWorkspaceDiskSpaceSummary(store, workspacePaths);
 }

--- a/libs/backend/election_package/election_package_io.ts
+++ b/libs/backend/election_package/election_package_io.ts
@@ -307,7 +307,7 @@ export async function readSignedElectionPackageFromUsb(
   // manager has authed. But we may reach this state if a user removes their card immediately
   // after inserting it, but after the election package configuration attempt has started
   if (authStatus.status !== 'logged_in') {
-    await logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
+    void logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
       disposition: 'failure',
       message: 'Election package configuration was attempted before auth.',
     });
@@ -335,7 +335,7 @@ export async function readSignedElectionPackageFromUsb(
         filePath: filepathResult.ok(),
       });
   if (artifactAuthenticationResult.isErr()) {
-    await logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
+    void logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
       disposition: 'failure',
       message: 'Election package authentication erred.',
     });
@@ -350,7 +350,7 @@ export async function readSignedElectionPackageFromUsb(
   );
 
   if (!deepEqual(authStatus.user.electionKey, electionKey)) {
-    await logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
+    void logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
       disposition: 'failure',
       message:
         'The election key for the authorized user and most recent election package on the USB drive did not match.',

--- a/libs/backend/system_call/export_logs_to_usb.ts
+++ b/libs/backend/system_call/export_logs_to_usb.ts
@@ -214,7 +214,7 @@ export async function exportLogsToUsb({
     logger,
   });
 
-  await logger.logAsCurrentRole(LogEventId.FileSaved, {
+  void logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: result.isOk() ? 'success' : 'failure',
     message: result.isOk()
       ? 'Successfully saved logs on the usb drive.'

--- a/libs/fujitsu-thermal-printer/src/logging.ts
+++ b/libs/fujitsu-thermal-printer/src/logging.ts
@@ -10,7 +10,7 @@ export async function logPrinterStatusIfChanged(
     return;
   }
   if (!previousStatus) {
-    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+    void logger.log(LogEventId.PrinterStatusChanged, 'system', {
       message: `Printer Status initiated with ${JSON.stringify(newStatus)}`,
       status: JSON.stringify(newStatus),
       disposition:
@@ -19,14 +19,14 @@ export async function logPrinterStatusIfChanged(
     return;
   }
   if (!newStatus) {
-    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+    void logger.log(LogEventId.PrinterStatusChanged, 'system', {
       message: `Printer status disconnected.`,
       disposition: 'failure',
     });
     return;
   }
   if (previousStatus.state !== newStatus.state) {
-    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+    void logger.log(LogEventId.PrinterStatusChanged, 'system', {
       message: `Printer Status updated from ${JSON.stringify(
         previousStatus
       )} to ${JSON.stringify(newStatus)}`,
@@ -38,7 +38,7 @@ export async function logPrinterStatusIfChanged(
     newStatus.state === 'error' &&
     previousStatus.type !== newStatus.type
   ) {
-    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+    void logger.log(LogEventId.PrinterStatusChanged, 'system', {
       message: `Printer Status updated from ${JSON.stringify(
         previousStatus
       )} to ${JSON.stringify(newStatus)}`,

--- a/libs/fujitsu-thermal-printer/src/logging.ts
+++ b/libs/fujitsu-thermal-printer/src/logging.ts
@@ -1,11 +1,11 @@
 import { BaseLogger, LogEventId } from '@vx/libs/logging/src';
 import { type PrinterStatus } from './types';
 
-export async function logPrinterStatusIfChanged(
+export function logPrinterStatusIfChanged(
   logger: BaseLogger,
   previousStatus?: PrinterStatus,
   newStatus?: PrinterStatus
-): Promise<void> {
+): void {
   if (!previousStatus && !newStatus) {
     return;
   }

--- a/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
@@ -138,7 +138,7 @@ export class MockFileFujitsuPrinter implements FujitsuThermalPrinterInterface {
 
   async getStatus(): Promise<PrinterStatus> {
     const newPrinterStatus = await Promise.resolve(readFromMockFile());
-    await logPrinterStatusIfChanged(
+    void logPrinterStatusIfChanged(
       this.logger,
       this.lastKnownStatus,
       newPrinterStatus || null

--- a/libs/fujitsu-thermal-printer/src/printer.ts
+++ b/libs/fujitsu-thermal-printer/src/printer.ts
@@ -65,7 +65,7 @@ export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
    */
   async getStatus(): Promise<PrinterStatus> {
     const newStatus = await this.getCurrentStatus();
-    await logPrinterStatusIfChanged(
+    void logPrinterStatusIfChanged(
       this.logger,
       this.lastKnownStatus,
       newStatus

--- a/libs/logging/README.md
+++ b/libs/logging/README.md
@@ -82,16 +82,16 @@ follows
 ```ts
 const { logger, currentUserSession } = useContext(AppContext);
 assert(currentUserSession.type === 'election_manager'); // Only election managers can import data
-await logger.log(LogEventId.ImportDataInit, currentUserSession.type); // There is no disposition, and a default message so no information needs to be passed to log.
+void logger.log(LogEventId.ImportDataInit, currentUserSession.type); // There is no disposition, and a default message so no information needs to be passed to log.
 try {
   const data = await importData();
-  await logger.log(LogEventId.ImportDataComplete, currentUserSession.type, {
+  void logger.log(LogEventId.ImportDataComplete, currentUserSession.type, {
     message: 'Import data completed successfully',
     disposition: 'success',
     fileImported: data.name,
   });
 } catch (err) {
-  await logger.log(LogEventId.ImportDataComplete, currentUserSession.type, {
+  void logger.log(LogEventId.ImportDataComplete, currentUserSession.type, {
     message: 'Error importing data.',
     disposition: 'failure',
     errorMessage: err.message,

--- a/libs/logging/src/export.ts
+++ b/libs/logging/src/export.ts
@@ -50,7 +50,7 @@ async function* generateCdfEventsForExport(
   for await (const [idx, log] of logs.enumerate()) {
     const decodedLogResult = safeParseJson(log, LogLineSchema);
     if (decodedLogResult.isErr()) {
-      await logger.logAsCurrentRole(LogEventId.LogConversionToCdfLogLineError, {
+      void logger.logAsCurrentRole(LogEventId.LogConversionToCdfLogLineError, {
         message: `Malformed log line identified, log line will be ignored: ${log} `,
         result: 'Log line will not be included in CDF output',
         disposition: 'failure',
@@ -118,7 +118,7 @@ export async function* buildCdfLog(
     GeneratedTime: new Date().toISOString(),
   };
 
-  await logger.logAsCurrentRole(LogEventId.LogConversionToCdfComplete, {
+  void logger.logAsCurrentRole(LogEventId.LogConversionToCdfComplete, {
     message: 'Log file successfully converted to CDF format.',
     disposition: 'success',
   });

--- a/libs/logging/src/export.ts
+++ b/libs/logging/src/export.ts
@@ -118,7 +118,7 @@ export async function* buildCdfLog(
     GeneratedTime: new Date().toISOString(),
   };
 
-  void logger.logAsCurrentRole(LogEventId.LogConversionToCdfComplete, {
+  await logger.logAsCurrentRole(LogEventId.LogConversionToCdfComplete, {
     message: 'Log file successfully converted to CDF format.',
     disposition: 'success',
   });

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -164,22 +164,19 @@ function isFat32(deviceInfo: BlockDeviceInfo): boolean {
   return deviceInfo.fstype === 'vfat' && deviceInfo.fsver === 'FAT32';
 }
 
-async function logMountInit(logger: BaseLogger): Promise<void> {
-  await logger.log(LogEventId.UsbDriveMountInit, 'system');
+function logMountInit(logger: BaseLogger): void {
+  void logger.log(LogEventId.UsbDriveMountInit, 'system');
 }
 
-async function logMountSuccess(logger: BaseLogger): Promise<void> {
-  await logger.log(LogEventId.UsbDriveMounted, 'system', {
+function logMountSuccess(logger: BaseLogger): void {
+  void logger.log(LogEventId.UsbDriveMounted, 'system', {
     disposition: 'success',
     message: 'USB drive successfully mounted.',
   });
 }
 
-async function logMountFailure(
-  logger: BaseLogger,
-  error: Error
-): Promise<void> {
-  await logger.log(LogEventId.UsbDriveMounted, 'system', {
+function logMountFailure(logger: BaseLogger, error: Error): void {
+  void logger.log(LogEventId.UsbDriveMounted, 'system', {
     disposition: 'failure',
     message: 'USB drive failed to mount.',
     error: error.message,
@@ -187,19 +184,19 @@ async function logMountFailure(
   });
 }
 
-export async function logEjectInit(logger: Logger): Promise<void> {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveEjectInit);
+export function logEjectInit(logger: Logger): void {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveEjectInit);
 }
 
-export async function logEjectSuccess(logger: Logger): Promise<void> {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
+export function logEjectSuccess(logger: Logger): void {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
     disposition: 'success',
     message: 'USB drive successfully ejected.',
   });
 }
 
-async function logEjectFailure(logger: Logger, error: Error): Promise<void> {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
+function logEjectFailure(logger: Logger, error: Error): void {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
     disposition: 'failure',
     message: 'USB drive failed to eject.',
     error: error.message,
@@ -207,19 +204,19 @@ async function logEjectFailure(logger: Logger, error: Error): Promise<void> {
   });
 }
 
-async function logFormatInit(logger: Logger) {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveFormatInit);
+function logFormatInit(logger: Logger) {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveFormatInit);
 }
 
-async function logFormatSuccess(logger: Logger, volumeName: string) {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
+function logFormatSuccess(logger: Logger, volumeName: string) {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
     disposition: 'success',
     message: `USB drive successfully formatted with a single FAT32 volume named "${volumeName}".`,
   });
 }
 
-async function logFormatFailure(logger: Logger, error: Error) {
-  await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
+function logFormatFailure(logger: Logger, error: Error) {
+  void logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
     disposition: 'failure',
     message: `Failed to format USB drive.`,
     error: error.message,
@@ -231,13 +228,13 @@ async function mount(
   deviceInfo: BlockDeviceInfo,
   logger: BaseLogger
 ): Promise<void> {
-  await logMountInit(logger);
+  logMountInit(logger);
   try {
     await mountUsbDrive(deviceInfo.path);
-    await logMountSuccess(logger);
+    logMountSuccess(logger);
     debug('USB drive mounted successfully');
   } catch (error) {
-    await logMountFailure(logger, error as Error);
+    logMountFailure(logger, error as Error);
     debug(`USB drive mounting failed: ${error}`);
     throw error;
   }
@@ -320,14 +317,14 @@ export function detectUsbDrive(logger: Logger): UsbDrive {
       }
 
       if (getActionLock('ejecting')) {
-        await logEjectInit(logger);
+        logEjectInit(logger);
         try {
           await unmountUsbDrive(deviceInfo.mountpoint);
           didEject = true;
-          await logEjectSuccess(logger);
+          logEjectSuccess(logger);
           debug('USB drive ejected successfully');
         } catch (error) {
-          await logEjectFailure(logger, error as Error);
+          logEjectFailure(logger, error as Error);
           debug(`USB drive ejection failed: ${error}`);
           throw error;
         } finally {
@@ -344,7 +341,7 @@ export function detectUsbDrive(logger: Logger): UsbDrive {
       }
 
       if (getActionLock('formatting')) {
-        await logFormatInit(logger);
+        logFormatInit(logger);
         try {
           if (deviceInfo.mountpoint) {
             debug('USB drive is mounted, unmounting before formatting');
@@ -353,10 +350,10 @@ export function detectUsbDrive(logger: Logger): UsbDrive {
 
           const label = generateVxUsbLabel(deviceInfo.label ?? undefined);
           await formatUsbDrive(getRootDeviceName(deviceInfo.path), label);
-          await logFormatSuccess(logger, label);
+          logFormatSuccess(logger, label);
           debug('USB drive formatted successfully');
         } catch (error) {
-          await logFormatFailure(logger, error as Error);
+          logFormatFailure(logger, error as Error);
           debug(`USB drive formatting failed: ${error}`);
           throw error;
         } finally {


### PR DESCRIPTION
- Use in-memory DBs: fairly substantial speedups for affected tests [~20%-40%]
- Call api methods directly instead of opening up a port and going through HTTP client: not much individual test speedup here, but trying to lessen the memory/CPU load overall
- Was curious about trimming async overhead for functions that wait on `logger.log`, but realised there aren't nearly enough of them to make a difference. Too many commits stacked on that one, so leaving in place all the same.

Potentially shaves off 1-1.5 mins from the app backend tests, but need to compare the next cache regeneration run against previous ones.