### PR TITLE
Increase timeout for ballot-interpreter e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
       - regenerate_cache
     triggers:
       - schedule:
-          cron: "0 10 * * 1-5"
+          cron: "0 10 * * *"
           filters:
             branches:
               only:

--- a/libs/ballot-interpreter/e2e/BUILD.bazel
+++ b/libs/ballot-interpreter/e2e/BUILD.bazel
@@ -4,6 +4,7 @@ load("//tools/ts_build:ts_tests.bzl", "ts_tests")
 ts_tests(
     name = "tests",
     size = "enormous",
+    timeout = "moderate",
     data = ["//libs/ballot-interpreter/test:fixtures_js"],
     shard_count = 4,
     deps = [


### PR DESCRIPTION
Timing out when running in the more crowded `daily_cache_regenerate` workflow.