### PR TITLE
Run ESLint checks in Bazel workers

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -3,6 +3,9 @@
 # NOTE: Keep in sync with .circleci/config.yml:
 common:ci --disk_cache=~/bazel_build_cache
 
+# Docs: https://bazel.build/docs/user-manual#keep-going
+common:ci --keep_going
+
 # Docs: https://bazel.build/docs/user-manual#test-output
 test:ci --test_output=errors
 

--- a/.bazel/convenience.bazelrc
+++ b/.bazel/convenience.bazelrc
@@ -1,5 +1,5 @@
 # Docs: https://bazel.build/docs/user-manual#keep-going
-common --keep_going
+common --nokeep_going
 
 # Docs: https://bazel.build/docs/user-manual#test-output
 test --test_output=errors

--- a/apps/admin/backend/app/app.auth.test.ts
+++ b/apps/admin/backend/app/app.auth.test.ts
@@ -63,7 +63,7 @@ test('logOut', async () => {
   const { api, auth } = buildTestEnvironment();
   await configureMachine(api, auth, electionDefinition, systemSettings);
 
-  await api.logOut();
+  api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
     electionKey,
@@ -155,10 +155,10 @@ test('checkPin before election definition has been configured', async () => {
   );
 });
 
-test('logOut before election definition has been configured', async () => {
+test('logOut before election definition has been configured', () => {
   const { api, auth } = buildTestEnvironment();
 
-  await api.logOut();
+  api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
     jurisdiction,

--- a/apps/admin/backend/store/store.ts
+++ b/apps/admin/backend/store/store.ts
@@ -1309,6 +1309,7 @@ export class Store {
         }).unsafeUnwrap()
       )
       .map<CastVoteRecordFileRecord>((parsedResult) => ({
+        /* eslint-disable-next-line vx/gts-spread-like-types */
         ...parsedResult,
         precinctIds: [...parsedResult.precinctIds].sort(),
         scannerIds: [...parsedResult.scannerIds].sort(),

--- a/apps/central-scan/backend/auth/auth.test.ts
+++ b/apps/central-scan/backend/auth/auth.test.ts
@@ -93,10 +93,10 @@ test('checkPin', async () => {
   );
 });
 
-test('logOut', async () => {
+test('logOut', () => {
   configureMachine(systemSettings);
 
-  await api.logOut();
+  api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
     electionKey,
@@ -144,8 +144,8 @@ test('checkPin before election definition has been configured', async () => {
   );
 });
 
-test('logOut before election definition has been configured', async () => {
-  await api.logOut();
+test('logOut before election definition has been configured', () => {
+  api.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, DEFAULT_SYSTEM_SETTINGS.auth);
 });

--- a/apps/scan/backend/app/app_auth.test.ts
+++ b/apps/scan/backend/app/app_auth.test.ts
@@ -86,7 +86,7 @@ test('logOut', async () => {
   await withApp(async ({ api, mockAuth, mockUsbDrive }) => {
     await configureApp(api, mockAuth, mockUsbDrive, { electionPackage });
 
-    await api.logOut();
+    api.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
     expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
       ...systemSettings.auth,
@@ -137,8 +137,8 @@ test('checkPin before election definition has been configured', async () => {
 });
 
 test('logOut before election definition has been configured', async () => {
-  await withApp(async ({ api, mockAuth }) => {
-    await api.logOut();
+  await withApp(({ api, mockAuth }) => {
+    api.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
     expect(mockAuth.logOut).toHaveBeenNthCalledWith(
       1,

--- a/env.d.ts
+++ b/env.d.ts
@@ -83,6 +83,18 @@ declare namespace NodeJS {
     BUILD_WORKSPACE_DIRECTORY?: string;
 
     /**
+     * Root-relative path to the config file for ESLint, when running under
+     * Bazel.
+     */
+    ESLINT_CONFIG_PATH?: string;
+
+    /**
+     * Root-relative path to the result formatter for ESLint, when running under
+     * Bazel.
+     */
+    ESLINT_FORMATTER_PATH?: string;
+
+    /**
      * The repo-relative path to the root of the currently running integration
      * test package.
      */

--- a/libs/ballot-interpreter/src/BUILD.bazel
+++ b/libs/ballot-interpreter/src/BUILD.bazel
@@ -10,7 +10,6 @@ ts_library(
     data = [":rust_addon"],
     deps = [
         "//:node_modules/@types/better-sqlite3",
-        "//:node_modules/@types/chalk",
         "//:node_modules/@types/debug",
         "//:node_modules/@types/node",
         "//:node_modules/@types/tmp",

--- a/libs/custom-scanner/src/BUILD.bazel
+++ b/libs/custom-scanner/src/BUILD.bazel
@@ -7,7 +7,6 @@ load("//tools/ts_build:ts_tests.bzl", "ts_tests")
 ts_library(
     name = "src",
     deps = [
-        "//:node_modules/@types/chalk",
         "//:node_modules/@types/debug",
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",

--- a/libs/test-utils/src/BUILD.bazel
+++ b/libs/test-utils/src/BUILD.bazel
@@ -8,7 +8,6 @@ ts_library(
     name = "src",
     deps = [
         "//:node_modules/@testing-library/react",
-        "//:node_modules/@types/chalk",
         "//:node_modules/@types/jest",
         "//:node_modules/@types/luxon",
         "//:node_modules/@types/node",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "zod": "3.23.5"
   },
   "devDependencies": {
+    "@bazel/worker": "^5.8.1",
     "@eslint/js": "8.57.1",
     "@jest/transform": "^29.7.0",
     "@jest/types": "29.6.3",
@@ -202,13 +203,12 @@
     "@testing-library/user-event": "13.5.0",
     "@types/base64-js": "1.3.0",
     "@types/better-sqlite3": "7.6.3",
-    "@types/chalk": "2.2.0",
     "@types/combined-stream": "1.0.3",
     "@types/compression": "1.7.2",
     "@types/connect": "3.4.35",
     "@types/debug": "4.1.8",
     "@types/deep-eql": "4.0.2",
-    "@types/eslint": "8.56.12",
+    "@types/eslint": "8.56.11",
     "@types/eslint-plugin-jsx-a11y": "^6.9.0",
     "@types/eslint__js": "8.42.3",
     "@types/express": "4.17.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ dependencies:
     version: 3.23.5
 
 devDependencies:
+  '@bazel/worker':
+    specifier: ^5.8.1
+    version: 5.8.1
   '@eslint/js':
     specifier: 8.57.1
     version: 8.57.1
@@ -569,9 +572,6 @@ devDependencies:
   '@types/better-sqlite3':
     specifier: 7.6.3
     version: 7.6.3
-  '@types/chalk':
-    specifier: 2.2.0
-    version: 2.2.0
   '@types/combined-stream':
     specifier: 1.0.3
     version: 1.0.3
@@ -588,8 +588,8 @@ devDependencies:
     specifier: 4.0.2
     version: 4.0.2
   '@types/eslint':
-    specifier: 8.56.12
-    version: 8.56.12
+    specifier: 8.56.11
+    version: 8.56.11
   '@types/eslint-plugin-jsx-a11y':
     specifier: ^6.9.0
     version: 6.9.0
@@ -754,7 +754,7 @@ devDependencies:
     version: 7.2.0(eslint@8.57.1)(typescript@5.6.2)
   '@typescript-eslint/rule-tester':
     specifier: 7.2.0
-    version: 7.2.0(@eslint/eslintrc@2.1.4)(eslint@8.57.1)(typescript@5.6.2)
+    version: 7.2.0(@eslint/eslintrc@3.2.0)(eslint@8.57.1)(typescript@5.6.2)
   '@typescript-eslint/utils':
     specifier: 7.2.0
     version: 7.2.0(eslint@8.57.1)(typescript@5.6.2)
@@ -805,7 +805,7 @@ devDependencies:
     version: 17.10.2(eslint@8.57.1)
   eslint-plugin-prettier:
     specifier: 5.2.1
-    version: 5.2.1(@types/eslint@8.56.12)(eslint-config-prettier@9.0.0)(eslint@8.57.1)(prettier@3.0.3)
+    version: 5.2.1(@types/eslint@8.56.11)(eslint-config-prettier@9.0.0)(eslint@8.57.1)(prettier@3.0.3)
   eslint-plugin-react:
     specifier: 7.37.1
     version: 7.37.1(eslint@8.57.1)
@@ -2587,6 +2587,12 @@ packages:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
     dev: true
 
+  /@bazel/worker@5.8.1:
+    resolution: {integrity: sha512-GMyZSNW3F34f9GjbJqvs1aHyed5BNrNeiDzNJhC1fIizo/UeBM21oBBONIYLBDoBtq936U85VyPZ76JaP/83hw==}
+    dependencies:
+      google-protobuf: 3.21.4
+    dev: true
+
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
@@ -3758,7 +3764,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@5.5.0)
       espree: 9.6.1
-      globals: 13.20.0
+      globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -3766,6 +3772,23 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@eslint/eslintrc@3.2.0:
+    resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@5.5.0)
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@eslint/js@8.57.1:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
@@ -6460,13 +6483,6 @@ packages:
     resolution: {integrity: sha512-2in/lrHRNmDvHPgyormtEralhPcN3An1gLjJzj2Bw145VBxkQ75JEXW6CTdMAwShiHQcYsl2d10IjQSdJSJz4g==}
     dev: false
 
-  /@types/chalk@2.2.0:
-    resolution: {integrity: sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==}
-    deprecated: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-
   /@types/combined-stream@1.0.3:
     resolution: {integrity: sha512-rU54Qy0+23b3xsXhBtHfx+M4lsRLllU2bnUnkS9hm3HAQ2Xt9q3QCYFxYVeaSG2mpCD8uuOGIEpcXHXDNZTa9w==}
     dependencies:
@@ -6528,11 +6544,11 @@ packages:
   /@types/eslint-plugin-jsx-a11y@6.9.0:
     resolution: {integrity: sha512-5nw0sPyYGCsFibwjOXftxends8Nrh/JLgDtBWj6aJVcN14kHwy1yIy0o1MGLKfCcR27pvUFGgYG+hX2HSX16uA==}
     dependencies:
-      '@types/eslint': 8.56.12
+      '@types/eslint': 8.56.11
     dev: true
 
-  /@types/eslint@8.56.12:
-    resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
+  /@types/eslint@8.56.11:
+    resolution: {integrity: sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==}
     dependencies:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.9
@@ -6541,7 +6557,7 @@ packages:
   /@types/eslint__js@8.42.3:
     resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
     dependencies:
-      '@types/eslint': 8.56.12
+      '@types/eslint': 8.56.11
     dev: true
 
   /@types/estree@0.0.51:
@@ -6667,8 +6683,8 @@ packages:
       parse5: 7.1.2
     dev: true
 
-  /@types/json-schema@7.0.12:
-    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
+  /@types/json-schema@7.0.15:
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
   /@types/json-schema@7.0.9:
@@ -7112,14 +7128,14 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/rule-tester@7.2.0(@eslint/eslintrc@2.1.4)(eslint@8.57.1)(typescript@5.6.2):
+  /@typescript-eslint/rule-tester@7.2.0(@eslint/eslintrc@3.2.0)(eslint@8.57.1)(typescript@5.6.2):
     resolution: {integrity: sha512-V/jxkkx+buBn9uM2QvdHzi1XzxBm2M+QpEORNZCRkq3vKhnZO2Sto1X0xaZ6vVbmHvOE+Zlkv7GO98PXvgGKVg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@eslint/eslintrc': '>=2'
       eslint: ^8.56.0
     dependencies:
-      '@eslint/eslintrc': 2.1.4
+      '@eslint/eslintrc': 3.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.6.2)
       '@typescript-eslint/utils': 7.2.0(eslint@8.57.1)(typescript@5.6.2)
       ajv: 6.12.6
@@ -7248,7 +7264,7 @@ packages:
       eslint: ^8.56.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 7.2.0
@@ -7538,12 +7554,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.10.0):
+  /acorn-jsx@5.3.2(acorn@8.14.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.14.0
 
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
@@ -7568,6 +7584,11 @@ packages:
 
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -10708,7 +10729,7 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /eslint-plugin-prettier@5.2.1(@types/eslint@8.56.12)(eslint-config-prettier@9.0.0)(eslint@8.57.1)(prettier@3.0.3):
+  /eslint-plugin-prettier@5.2.1(@types/eslint@8.56.11)(eslint-config-prettier@9.0.0)(eslint@8.57.1)(prettier@3.0.3):
     resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -10722,7 +10743,7 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@types/eslint': 8.56.12
+      '@types/eslint': 8.56.11
       eslint: 8.57.1
       eslint-config-prettier: 9.0.0(eslint@8.57.1)
       prettier: 3.0.3
@@ -10809,6 +10830,11 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  /eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: true
+
   /eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10838,7 +10864,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.24.0
       graphemer: 1.4.0
       ignore: 5.3.2
       imurmurhash: 0.1.4
@@ -10861,12 +10887,21 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /espree@10.3.0:
+    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
+      eslint-visitor-keys: 4.2.0
+    dev: true
+
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.10.0
-      acorn-jsx: 5.3.2(acorn@8.10.0)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.3
 
   /esprima@4.0.1:
@@ -11897,11 +11932,16 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+
+  /globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+    dev: true
 
   /globals@15.10.0:
     resolution: {integrity: sha512-tqFIbz83w4Y5TCbtgjZjApohbuh7K9BxGYFm7ifwDR240tvdb7P9x+/9VvUKlmkPoiknoJtanI8UOrqxS3a7lQ==}
@@ -12002,6 +12042,10 @@ packages:
       - encoding
       - supports-color
     dev: false
+
+  /google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
+    dev: true
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -18330,7 +18374,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.14.0
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21

--- a/tools/eslint/BUILD.bazel
+++ b/tools/eslint/BUILD.bazel
@@ -49,3 +49,10 @@ sh_binary(
 eslint.eslint_binary(name = "binary")
 
 lint_test(name = "lint")
+
+exports_files(
+    [
+        "checker.sh.template",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/eslint/checker.sh.template
+++ b/tools/eslint/checker.sh.template
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+exec {{CHECKER_EXE}} {{FILES}}

--- a/tools/eslint/checker/BUILD.bazel
+++ b/tools/eslint/checker/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("//tools/ts_build:lint_test.bzl", "lint_test")
+load("//tools/ts_build:ts_library.bzl", "ts_library")
+
+ts_library(
+    name = "checker",
+    deps = [
+        "//:node_modules/@types/node",
+        "//:node_modules/chalk",
+    ],
+)
+
+lint_test(name = "lint")
+
+js_binary(
+    name = "exe",
+    data = [
+        ":checker",
+        "//tools/eslint",
+        "//tools/eslint:config.js",
+    ],
+    entry_point = "checker.js",
+    env = {
+        "BAZEL_BINDIR": ".",
+        "ESLINT_CONFIG_PATH": "$(execpath //tools/eslint:config.js)",
+    },
+    patch_node_fs = False,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/eslint/checker/checker.ts
+++ b/tools/eslint/checker/checker.ts
@@ -1,0 +1,33 @@
+import chalk from 'chalk';
+import fs from 'node:fs/promises';
+import process from 'node:process';
+
+chalk.level = 3;
+
+async function main() {
+  let hasErrors = false;
+
+  for (let i = 2; i < process.argv.length; i += 1) {
+    const filePath = process.argv[i];
+    const contents = await fs.readFile(filePath, 'utf8');
+    if (contents.length === 0) {
+      continue;
+    }
+
+    hasErrors = true;
+    console.error(contents);
+  }
+
+  process.exit(hasErrors ? 1 : 0);
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(
+      chalk.red('\n[ERROR] unable to read ESLint output:', error, '\n')
+    );
+    process.exit(1);
+  });

--- a/tools/eslint/config.ts
+++ b/tools/eslint/config.ts
@@ -23,6 +23,14 @@ const tsExtensions = ['.ts', '.tsx'];
 const allExtensions = jsExtensions.concat(tsExtensions);
 
 module.exports = [
+  {
+    settings: {
+      react: {
+        version: 'detect',
+        defaultVersion: '18.3.1',
+      },
+    },
+  },
   pluginImports.flatConfigs.errors,
   pluginImports.flatConfigs.warnings,
   eslintJs.configs.recommended,
@@ -258,11 +266,6 @@ module.exports = [
       react: pluginReact,
       'react-hooks': {
         rules: pluginReactHooks.rules,
-      },
-    },
-    settings: {
-      react: {
-        version: 'detect',
       },
     },
     rules: {

--- a/tools/eslint/formatter/BUILD.bazel
+++ b/tools/eslint/formatter/BUILD.bazel
@@ -4,7 +4,6 @@ load("//tools/ts_build:ts_library.bzl", "ts_library")
 ts_library(
     name = "formatter",
     deps = [
-        "//:node_modules/@types/chalk",
         "//:node_modules/@types/eslint",
         "//:node_modules/@types/node",
         "//:node_modules/@types/text-table",

--- a/tools/eslint/formatter/formatter.ts
+++ b/tools/eslint/formatter/formatter.ts
@@ -12,6 +12,8 @@ import table from 'text-table';
 import util from 'node:util';
 import { ESLint } from 'eslint';
 
+chalk.level = 3;
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -115,7 +117,7 @@ function format(
           ' and ',
           fixableWarningCount,
           pluralize(' warning', fixableWarningCount),
-          ' potentially fixable with the `--fix` option.\n',
+          ' potentially fixable with the `--fix` option!!!\n',
         ].join('')
       );
     }

--- a/tools/eslint/worker/BUILD.bazel
+++ b/tools/eslint/worker/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("//tools/ts_build:lint_test.bzl", "lint_test")
+load("//tools/ts_build:ts_library.bzl", "ts_library")
+
+ts_library(
+    name = "worker",
+    data = [
+        "//tools/eslint/formatter",
+    ],
+    deps = [
+        "//:node_modules/@bazel/worker",
+        "//:node_modules/@types/eslint",
+        "//:node_modules/@types/node",
+        "//:node_modules/chalk",
+        "//:node_modules/eslint",
+        "//:types_env",
+    ],
+)
+
+lint_test(name = "lint")
+
+js_binary(
+    name = "exe",
+    data = [
+        "//tools/eslint",
+        "//tools/eslint:config.js",
+        "//tools/eslint/formatter",
+        "//tools/eslint/formatter:formatter.js",
+    ],
+    entry_point = "worker.js",
+    env = {
+        "BAZEL_BINDIR": ".",
+        "ESLINT_CONFIG_PATH": "$(execpath //tools/eslint:config.js)",
+        "ESLINT_FORMATTER_PATH": "$(execpath //tools/eslint/formatter:formatter.js)",
+    },
+    patch_node_fs = False,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/eslint/worker/worker.ts
+++ b/tools/eslint/worker/worker.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable vx/gts-identifiers */
+import chalk from 'chalk';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import util from 'node:util';
+import { ESLint } from 'eslint';
+import { FlatESLint } from 'eslint/use-at-your-own-risk';
+import { runWorkerLoop, log } from '@bazel/worker';
+
+chalk.level = 3;
+
+declare module 'eslint/use-at-your-own-risk' {
+  class FlatESLint extends ESLint {}
+}
+
+const cwd = process.cwd();
+
+const eslint = new FlatESLint({
+  overrideConfigFile: process.env.ESLINT_CONFIG_PATH,
+  cwd,
+});
+
+void runWorkerLoop(async (args) => {
+  const {
+    positionals: inputPaths,
+    values: { outputPath },
+  } = util.parseArgs({
+    allowPositionals: true,
+    args,
+    options: {
+      outputPath: { short: 'o', type: 'string' },
+    },
+    strict: true,
+  });
+
+  if (!outputPath) {
+    log(chalk.red('\n[ERROR] missing output file path\n'));
+    return false;
+  }
+
+  if (!inputPaths) {
+    log(chalk.red('\n[ERROR] missing input file paths\n'));
+    return false;
+  }
+
+  try {
+    const [results, formatter] = await Promise.all([
+      eslint.lintFiles(inputPaths),
+      eslint.loadFormatter(process.env.ESLINT_FORMATTER_PATH),
+    ]);
+
+    let output = '';
+
+    const hasErrors = results.some((r) => r.messages.length === 0);
+    if (hasErrors) {
+      output = await formatter.format(results, {
+        cwd,
+        rulesMeta: eslint.getRulesMetaForResults(results),
+      });
+    }
+
+    await fs.writeFile(path.join(cwd, outputPath), output, 'utf-8');
+  } catch (error) {
+    log(chalk.red(`\n[ERROR] ESLint failed: ${error}\n`));
+    return false;
+  }
+
+  return true;
+});

--- a/tools/multirun/BUILD.bazel
+++ b/tools/multirun/BUILD.bazel
@@ -4,7 +4,6 @@ load("//tools/ts_build:ts_library.bzl", "ts_library")
 ts_library(
     name = "multirun",
     deps = [
-        "//:node_modules/@types/chalk",
         "//:node_modules/@types/node",
         "//:node_modules/chalk",
         "//:node_modules/concurrently",

--- a/tools/ts_build/lint_test.bzl
+++ b/tools/ts_build/lint_test.bzl
@@ -3,7 +3,6 @@ load(":files.bzl", "list_all_files")
 
 def lint_test(
         name = "lib",
-        data = [],
         size = "medium",
         tags = [],
         timeout = "short",
@@ -13,7 +12,6 @@ def lint_test(
     Args:
       name: Name for the build target. This should usually match the name of
           the package/directory.
-      data: Data/script/asset files that are written/read at runtime.
       size: Size tag for the test target - defaults to "small".
       tags: Additional tags to attach to the generated targets.
       timeout: Timeout ("short" | "moderate" | "long" | "eternal") for the
@@ -24,7 +22,6 @@ def lint_test(
     eslint_test(
         name = name,
         srcs = list_all_files(),
-        data = data,
         size = size,
         tags = tags + ["lint"],
         timeout = timeout,


### PR DESCRIPTION
Been wanting to get around to this - moving the ESLint checks to the Bazel worker model to avoid the spin-up cost for each lint target Makes things slower for the initial run on a clean repo or after edits to the ESLint tooling, but subsequent runs benefit from the fact that the node process is already spun up and ESLint config has been loaded.

Seeing a ~50% time reduction locally and in CI - should be a much more substantial reduction in the scaling factor as more code is added.