### PR TITLE
Copy over PR 5611 from upstream

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -20,8 +20,8 @@ common:ci --local_resources=cpu=8
 
 # Set limits for the Bazel worker instances.
 # https://bazel.build/reference/command-line-reference#flag--worker_max_instances
-common:ci --worker_max_instances=ESLint=8
-common:ci --worker_max_instances=TSBuild=8
+common:ci --worker_max_instances=ESLint=7
+common:ci --worker_max_instances=TSBuild=7
 
 # Machines in CircleCI may have more cores than what's allocated to a workflow,
 # so we need to explicitly limit Bazel CPU usage to 8 cores to avoid

--- a/.bazel/performance.bazelrc
+++ b/.bazel/performance.bazelrc
@@ -29,4 +29,4 @@ common --compilation_mode=opt
 # from overrunning the system.
 # https://bazel.build/reference/command-line-reference#flag--worker_max_instances
 common --worker_max_instances=ESLint=HOST_CPUS*0.5
-common --worker_max_instances=TSBuild=HOST_CPUS
+common --worker_max_instances=TSBuild=HOST_CPUS*0.8

--- a/apps/mark-scan/backend/audio/BUILD.bazel
+++ b/apps/mark-scan/backend/audio/BUILD.bazel
@@ -6,6 +6,8 @@ ts_library(
     deps = [
         "//apps/mark-scan/backend/globals",
         "//libs/backend/command_line",
+        "//libs/basics/async",
+        "//libs/logging/src",
     ],
 )
 

--- a/apps/mark-scan/backend/audio/outputs.test.ts
+++ b/apps/mark-scan/backend/audio/outputs.test.ts
@@ -1,0 +1,73 @@
+jest.mock('@votingworks/backend');
+
+jest.mock('../globals');
+
+jest.mock(
+  '@vx/libs/basics/async',
+  (): typeof import('@vx/libs/basics/async') => ({
+    ...jest.requireActual('@vx/libs/basics/async'),
+    sleep: jest.fn(),
+  })
+);
+
+import { mockOf } from '@vx/libs/test-utils/src';
+import {
+  AudioOutput,
+  MAX_PULSE_COMMAND_ATTEMPTS,
+  setAudioOutput,
+} from './outputs';
+import { execFile } from '@vx/libs/backend/command_line';
+import { sleep } from '@vx/libs/basics/async';
+import { LogEventId, mockLogger } from '@vx/libs/logging/src';
+import { getNodeEnv } from '../globals/globals';
+
+const mockExecFile = mockOf(execFile);
+const mockSleep = mockOf(sleep);
+const mockGetNodeEnv = mockOf(getNodeEnv);
+const mockLog = mockLogger();
+
+test('setAudioOutput - success on retry', async () => {
+  mockGetNodeEnv.mockReturnValue('production');
+  mockSleep.mockResolvedValue();
+  mockExecFile.mockRejectedValueOnce('command failed');
+  mockExecFile.mockResolvedValueOnce({ stdout: 'ok', stderr: '' });
+
+  await setAudioOutput(AudioOutput.SPEAKER, mockLog);
+
+  expect(mockExecFile).toHaveBeenCalledTimes(2);
+  expect(mockSleep).toHaveBeenCalledTimes(1);
+  expect(mockLog.log).toHaveBeenCalledTimes(1);
+  expect(mockLog.log).toHaveBeenCalledWith(
+    LogEventId.Info,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('command failed'),
+    })
+  );
+});
+
+test('setAudioOutput - retries and rethrows on failure', async () => {
+  mockGetNodeEnv.mockReturnValue('production');
+  mockSleep.mockResolvedValue();
+  mockExecFile.mockRejectedValue('command failed');
+
+  await expect(() =>
+    setAudioOutput(AudioOutput.SPEAKER, mockLog)
+  ).rejects.toMatchObject({
+    message: /command failed/,
+  });
+
+  expect(mockExecFile).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS);
+  expect(mockSleep).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS - 1);
+  expect(mockLog.log).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS - 1);
+});
+
+test('setAudioOutput - no-op in non-prod environments', async () => {
+  mockGetNodeEnv.mockReturnValue('development');
+
+  await setAudioOutput(AudioOutput.SPEAKER, mockLog);
+
+  expect(mockExecFile).not.toHaveBeenCalled();
+  expect(mockSleep).not.toHaveBeenCalled();
+  expect(mockLog.log).not.toHaveBeenCalled();
+});

--- a/apps/mark-scan/backend/audio/outputs.ts
+++ b/apps/mark-scan/backend/audio/outputs.ts
@@ -1,7 +1,10 @@
 /* istanbul ignore file */
 import { execFile } from '@vx/libs/backend/command_line';
-import { NODE_ENV } from '../globals/globals';
+import { getNodeEnv } from '../globals/globals';
+import { LogEventId, Logger } from '@vx/libs/logging/src';
+import { sleep } from '@vx/libs/basics/async';
 
+export const MAX_PULSE_COMMAND_ATTEMPTS = 3;
 const PULSE_AUDIO_SINK_ID_VSAP_SOUND_CARD = '0';
 
 /**
@@ -17,8 +20,8 @@ export enum AudioOutput {
  * Sets the active audio output port.
  * NOTE: This is only guaranteed to work on production hardware.
  */
-export async function setAudioOutput(outputName: AudioOutput): Promise<void> {
-  if (NODE_ENV !== 'production') {
+async function setAudioOutputFn(outputName: AudioOutput): Promise<void> {
+  if (getNodeEnv() !== 'production') {
     return;
   }
 
@@ -38,4 +41,36 @@ export async function setAudioOutput(outputName: AudioOutput): Promise<void> {
   if (errorOutput) {
     throw new Error(`Unable to set audio output: ${errorOutput}}`);
   }
+}
+
+/**
+ * Sets the active audio output port.
+ * NOTE: This is only guaranteed to work on production hardware.
+ */
+export async function setAudioOutput(
+  outputName: AudioOutput,
+  logger: Logger
+): Promise<void> {
+  const baseWaitTimeMs = 1000;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lastError: any;
+  for (let i = 0; i < MAX_PULSE_COMMAND_ATTEMPTS; i += 1) {
+    if (i > 0) {
+      void logger.log(LogEventId.Info, 'system', {
+        message:
+          `Unable to set audio output to ${outputName} - ` +
+          `retrying after error: ${lastError}`,
+      });
+      await sleep(baseWaitTimeMs * i);
+    }
+
+    try {
+      return await setAudioOutputFn(outputName);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
 }

--- a/apps/mark-scan/backend/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/custom-paper-handler/state_machine.test.ts
@@ -1256,7 +1256,8 @@ describe('open cover detection', () => {
     await setMockCoverOpen(true);
     expect(machine.getSimpleStatus()).toEqual('cover_open_unauthorized');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.SPEAKER
+      AudioOutput.SPEAKER,
+      expect.anything() // logger
     );
 
     // Stops triggering for Poll Worker:
@@ -1265,7 +1266,8 @@ describe('open cover detection', () => {
     await sleep(0);
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.HEADPHONES
+      AudioOutput.HEADPHONES,
+      expect.anything() // logger
     );
 
     // Stops triggering for EM:
@@ -1286,14 +1288,16 @@ describe('open cover detection', () => {
     await sleep(0);
     expect(machine.getSimpleStatus()).toEqual('cover_open_unauthorized');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.SPEAKER
+      AudioOutput.SPEAKER,
+      expect.anything() // logger
     );
 
     // Close cover to stop triggering:
     await setMockCoverOpen(false);
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.HEADPHONES
+      AudioOutput.HEADPHONES,
+      expect.anything() // logger
     );
   });
 

--- a/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/custom-paper-handler/state_machine.ts
@@ -1385,8 +1385,8 @@ export function buildMachine(
         },
         cover_open_unauthorized: {
           invoke: pollCoverOpenStatus,
-          entry: () => setAudioOutput(AudioOutput.SPEAKER),
-          exit: () => setAudioOutput(AudioOutput.HEADPHONES),
+          entry: ({ logger }) => setAudioOutput(AudioOutput.SPEAKER, logger),
+          exit: ({ logger }) => setAudioOutput(AudioOutput.HEADPHONES, logger),
           on: {
             AUTH_STATUS_LOGGED_OUT: 'voting_flow.history',
             AUTH_STATUS_POLL_WORKER: 'voting_flow.history',

--- a/apps/mark-scan/backend/globals/globals.ts
+++ b/apps/mark-scan/backend/globals/globals.ts
@@ -15,13 +15,19 @@ const NodeEnvSchema = z.union([
   z.literal('production'),
 ]);
 
-/**
- * Which node environment is this?
- */
-export const NODE_ENV = unsafeParse(
+const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env.NODE_ENV ?? 'development'
 );
+
+/**
+ * Which node environment is this?
+ *
+ * NOTE: Exposed as a function to enable mocking.
+ */
+export function getNodeEnv(): z.TypeOf<typeof NodeEnvSchema> {
+  return NODE_ENV;
+}
 
 const REPO_ROOT =
   process.env.BUILD_WORKSPACE_DIRECTORY || join(__dirname, '../../..');

--- a/tools/eslint/worker/BUILD.bazel
+++ b/tools/eslint/worker/BUILD.bazel
@@ -23,6 +23,7 @@ lint_test(name = "lint")
 js_binary(
     name = "exe",
     data = [
+        ":worker",
         "//tools/eslint",
         "//tools/eslint:config.js",
         "//tools/eslint/formatter",

--- a/tools/ts_build/worker/worker.mjs
+++ b/tools/ts_build/worker/worker.mjs
@@ -64,6 +64,7 @@ const diagnosticFormatHost = {
   getNewLine: () => '\n',
 };
 
+tsconfigJson.compilerOptions.allowJs = false;
 tsconfigJson.compilerOptions.noEmit = false;
 const tsconfig = tsc.convertCompilerOptionsFromJson(
   tsconfigJson.compilerOptions,


### PR DESCRIPTION
Testing out a semi-contained change to validate the new builder.

Ran into a bug related to the `tsc` program trying to pick up pre-cached `.js` files and emit them - fixed by disabling `allowJs` in the build-specific tsconfig, but need to revisit to make sure other potentially pre-cached files won't trip it up somehow.

Also fixing a missing dependency in the ESLint worker.