### PR TITLE
[TSBuild] Performance tweaks for the TSBuild worker

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -19,9 +19,18 @@ build:ci --show_result=1
 common:ci --local_resources=cpu=8
 
 # Set limits for the Bazel worker instances.
+#
+# ESLint workers are quite chonky, so pushing past 7 workers is risky with the
+# 16GB allocation in CircleCI (each worker can use upwards of 1.5GB for larger
+# packages).
+#
+# The TSBuild graph only has parallel speed gains up to ~6 workers for a full
+# repo build at the moment. More package splitting might bump that up a bit, but
+# probably not by much, given the nature of the connections.
+#
 # https://bazel.build/reference/command-line-reference#flag--worker_max_instances
 common:ci --worker_max_instances=ESLint=7
-common:ci --worker_max_instances=TSBuild=7
+common:ci --worker_max_instances=TSBuild=6
 
 # Machines in CircleCI may have more cores than what's allocated to a workflow,
 # so we need to explicitly limit Bazel CPU usage to 8 cores to avoid

--- a/.bazel/performance.bazelrc
+++ b/.bazel/performance.bazelrc
@@ -25,8 +25,14 @@ build --nolegacy_external_runfiles
 common --compilation_mode=opt
 
 # Set limits for the Bazel worker instances.
+#
 # ESLint workers are quite chonky. Conservatively limit to CPUS/2 to keep them
 # from overrunning the system.
+#
+# The TSBuild graph only has parallel speed gains up to ~6 workers for a full
+# repo build at the moment. More package splitting might bump that up a bit, but
+# probably not by much, given the nature of the connections.
+#
 # https://bazel.build/reference/command-line-reference#flag--worker_max_instances
 common --worker_max_instances=ESLint=HOST_CPUS*0.5
-common --worker_max_instances=TSBuild=HOST_CPUS*0.8
+common --worker_max_instances=TSBuild=6


### PR DESCRIPTION
After playing around locally with the `tsc` API options, it seems like there's a slight boost from holding on to the last `program` created in each worker and feeding it into the next, to benefit from any reusable type information from the last run. IIUC, this parallels the behaviour of the compiler when used with `.tsbuildinfo` files in the `incremental` build modes.

Also reducing the max worker count to `6` - didn't see benefits locally past `5` for average changes to the build graph (e.g. re-building all of `//libs/...`, and nothing past `6` for a full graph re-build. `5` is probably the better sweet spot for CI , but will see how the next few runs go.