### PR TITLE
[TSBuild] Split transpile/typecheck graphs, transpile with esbuild

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -20,7 +20,7 @@ common:ci --local_resources=cpu=8
 
 # Set limits for the Bazel worker instances.
 #
-# ESLint workers are quite chonky, so pushing past 7 workers is risky with the
+# ESLint workers are quite chonky, so pushing past 6 workers is risky with the
 # 16GB allocation in CircleCI (each worker can use upwards of 1.5GB for larger
 # packages).
 #
@@ -29,7 +29,7 @@ common:ci --local_resources=cpu=8
 # probably not by much, given the nature of the connections.
 #
 # https://bazel.build/reference/command-line-reference#flag--worker_max_instances
-common:ci --worker_max_instances=ESLint=7
+common:ci --worker_max_instances=ESLint=6
 common:ci --worker_max_instances=TSBuild=6
 
 # Machines in CircleCI may have more cores than what's allocated to a workflow,

--- a/.bazel/convenience.bazelrc
+++ b/.bazel/convenience.bazelrc
@@ -1,5 +1,5 @@
 # Docs: https://bazel.build/docs/user-manual#keep-going
-common --nokeep_going
+common --keep_going
 
 # Docs: https://bazel.build/docs/user-manual#test-output
 test --test_output=errors
@@ -25,3 +25,6 @@ common --heap_dump_on_oom
 
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
 common --noincompatible_disallow_empty_glob
+
+build --build_tag_filters=-lint,-typecheck
+test --test_tag_filters=-lint --build_tag_filters=-lint,-typecheck

--- a/apps/central-scan/frontend/screens/scan/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/screens/scan/scan_ballots_screen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import pluralizeLib from 'pluralize';
+import pluralize from 'pluralize';
 import { Button } from '@vx/libs/ui/buttons';
 import { Font, Icons, P, Loading } from '@vx/libs/ui/primitives';
 import { TD, Table } from '@vx/libs/ui/src';
@@ -13,12 +13,6 @@ import { NavigationScreen } from '../nav/navigation_screen';
 import { ExportResultsModal } from '../../components/export_results_modal';
 import { ScanButton } from '../../components/scan_button';
 import { clearBallotData } from '../../api/api';
-
-// [TODO] esbuild bundler imports this as a module with `pluralize` nested -
-// not sure why yet.
-const pluralize = ('pluralize' in pluralizeLib
-  ? pluralizeLib.pluralize
-  : pluralizeLib) as unknown as typeof pluralizeLib;
 
 pluralize.addIrregularRule('requires', 'require');
 pluralize.addIrregularRule('has', 'have');

--- a/libs/ui/ballots/bmd_paper_ballot.test.tsx
+++ b/libs/ui/ballots/bmd_paper_ballot.test.tsx
@@ -19,6 +19,11 @@ jest.mock('@vx/libs/utils/src', (): typeof import('@vx/libs/utils/src') => {
   };
 });
 
+jest.mock('./qrcode', (): typeof import('./qrcode') => ({
+  ...jest.requireActual('./qrcode'),
+  QrCode: jest.fn(jest.requireActual('./qrcode').QrCode),
+}));
+
 import {
   type BallotStyleId,
   BallotType,
@@ -52,7 +57,7 @@ import {
   MAX_MARK_SCAN_TOP_MARGIN,
   type BmdBallotSheetSize,
 } from './bmd_paper_ballot';
-import * as QrCodeModule from './qrcode';
+import { QrCode } from './qrcode';
 
 const encodeBallotMock = mockOf(encodeBallot);
 const mockEncodedBallotData = new Uint8Array([0, 1, 2, 3]);
@@ -243,8 +248,6 @@ test('BmdPaperBallot renders seal', () => {
 });
 
 test('BmdPaperBallot passes expected data to encodeBallot for use in QR code', () => {
-  const QrCodeSpy = jest.spyOn(QrCodeModule, 'QrCode');
-
   renderBmdPaperBallot({
     electionDefinition: electionGeneralDefinition,
     ballotStyleId: '5' as BallotStyleId,
@@ -274,7 +277,7 @@ test('BmdPaperBallot passes expected data to encodeBallot for use in QR code', (
     })
   );
 
-  expect(QrCodeSpy).toBeCalledWith(
+  expect(mockOf(QrCode)).toBeCalledWith(
     expect.objectContaining({
       value: fromByteArray(mockEncodedBallotData),
     }),

--- a/libs/ui/language_settings/language_settings_button.test.tsx
+++ b/libs/ui/language_settings/language_settings_button.test.tsx
@@ -119,6 +119,7 @@ test('plays audio instructions in all languages', async () => {
     screen.getByTestId(MOCK_ALT_AUDIO_PRIMARY_TEXT_TEST_ID)
   ).toHaveTextContent('Español');
 
+  await advancePromises();
   expect(screen.getByTestId(MOCK_ALT_AUDIO_ALT_TEXT_TEST_ID)).toHaveTextContent(
     [
       '(Spanish Label) Español',

--- a/tools/jest/patch_styled_components.ts
+++ b/tools/jest/patch_styled_components.ts
@@ -1,0 +1,5 @@
+// styled-components version 5.3.1 and above requires this remapping for jest
+// environments, reference: https://github.com/styled-components/styled-components/issues/3570
+jest.mock('styled-components', (): typeof import('styled-components') =>
+  jest.requireActual('styled-components/dist/styled-components.browser.cjs.js')
+);

--- a/tools/jest/setup_dom.ts
+++ b/tools/jest/setup_dom.ts
@@ -1,8 +1,4 @@
-// styled-components version 5.3.1 and above requires this remapping for jest
-// environments, reference: https://github.com/styled-components/styled-components/issues/3570
-jest.mock('styled-components', (): typeof import('styled-components') =>
-  jest.requireActual('styled-components/dist/styled-components.browser.cjs.js')
-);
+import './patch_styled_components';
 
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-styled-components';

--- a/tools/ts_build/worker/worker.mjs
+++ b/tools/ts_build/worker/worker.mjs
@@ -66,9 +66,6 @@ const diagnosticFormatHost = {
 
 // Avoid trying to recompile cached .js files:
 tsconfigJson.compilerOptions.allowJs = false;
-
-tsconfigJson.compilerOptions.noEmit = false;
-
 const tsconfig = tsc.convertCompilerOptionsFromJson(
   tsconfigJson.compilerOptions,
   CWD

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "alwaysStrict": true,
     "baseUrl": ".",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "esModuleInterop": true,
+    "emitDeclarationOnly": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSourceMap": true,
@@ -16,7 +17,6 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noFallthroughCasesInSwitch": true,
-    "noEmit": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": false,
     "noUnusedLocals": false,
@@ -24,6 +24,7 @@
     "paths": {
       "@vx/*": ["*"]
     },
+    "removeComments": true,
     "resolveJsonModule": true,
     "skipDefaultLibCheck": false,
     "skipLibCheck": true,


### PR DESCRIPTION
Follow-up to https://github.com/kofi-q/vxsweet/pull/55

Moving off `aspect-build/rules_ts` allows for a bit more flexibility with separating out the transpile/typecheck graphs (e.g. they can be tagged differently and ran separately more easily locally).

There should be slightly less bottlenecking in CI as well, since tests can start much earlier after transpilation and run parallel to the (now-typecheck-only) tsc workers.