### PR TITLE
[rs] Move rustfmt and clippy to explicit bazel targets

### DIFF
--- a/.bazel/ci.bazelrc
+++ b/.bazel/ci.bazelrc
@@ -45,12 +45,3 @@ common:ci --keep_going
 # Make sure we have as much info in the CI output as possible to debug failures.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 common:ci --verbose_failures
-
-# Enable rustfmt checks as part of the CI build.
-# Not currently enabled locally to ease dev iteration, assuming rustfmt is
-# enabled in the IDE.
-# TODO: Set up pre-commit hooks for linting/formatting.
-#
-# https://bazelbuild.github.io/rules_rust/rust_fmt.html#setup
-build:ci --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:ci --output_groups=+rustfmt_checks

--- a/.bazel/rust.bazelrc
+++ b/.bazel/rust.bazelrc
@@ -7,11 +7,9 @@ common --action_env=CARGO_PKG_LICENSE="AGPL-3.0"
 common --action_env=CARGO_PKG_REPOSITORY="https://github.com/votingworks/vxsuite"
 common --action_env=RUSTDOC="None"
 
-# Enable clippy checks on all Rust targets.
+# Configure clippy checks for all `rust_clippy` targets.
 # See https://bazelbuild.github.io/rules_rust/rust_clippy.html#setup
-build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --@rules_rust//:clippy_flag="-Aclippy::pedantic"
 build --@rules_rust//:clippy_flag="-Aclippy::nursery"
 build --@rules_rust//:clippy_flag="-Aclippy::unwrap_used"
 build --@rules_rust//:clippy_flag="-Aclippy::result_large_err"
-build --output_groups=+clippy_checks

--- a/apps/mark-scan/accessible-controller/BUILD.bazel
+++ b/apps/mark-scan/accessible-controller/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_test", "rustfmt_test")
 
 rust_binary(
     name = "accessible-controller",
@@ -27,4 +27,21 @@ rust_test(
     name = "tests",
     size = "small",
     crate = ":accessible-controller",
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":accessible-controller",
+        ":tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":accessible-controller",
+        ":tests",
+    ],
 )

--- a/apps/mark-scan/daemon-utils/BUILD.bazel
+++ b/apps/mark-scan/daemon-utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "daemon-utils",
@@ -8,5 +8,20 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "//libs/logging:rust",
+    ],
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":daemon-utils",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":daemon-utils",
     ],
 )

--- a/apps/mark-scan/fai-100-controller/BUILD.bazel
+++ b/apps/mark-scan/fai-100-controller/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_test", "rustfmt_test")
 
 rust_binary(
     name = "fai-100-controller",
@@ -26,4 +26,21 @@ rust_test(
     name = "tests",
     size = "small",
     crate = ":fai-100-controller",
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":fai-100-controller",
+        ":tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":fai-100-controller",
+        ":tests",
+    ],
 )

--- a/apps/mark-scan/pat-device-input/BUILD.bazel
+++ b/apps/mark-scan/pat-device-input/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_test", "rustfmt_test")
 
 rust_binary(
     name = "pat-device-input",
@@ -20,4 +20,21 @@ rust_test(
     name = "tests",
     size = "small",
     crate = ":pat-device-input",
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":pat-device-input",
+        ":tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":pat-device-input",
+        ":tests",
+    ],
 )

--- a/libs/ballot-interpreter/BUILD.bazel
+++ b/libs/ballot-interpreter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_shared_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_shared_library", "rust_test", "rustfmt_test")
 
 DATA_FILE_EXTENSIONS = [
     "png",
@@ -54,5 +54,22 @@ rust_test(
     deps = [
         "@crates//:proptest",
         "@crates//:tempfile",
+    ],
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":rust",
+        ":rust_tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":rust",
+        ":rust_tests",
     ],
 )

--- a/libs/libudev-sys/BUILD.bazel
+++ b/libs/libudev-sys/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "libudev-sys",
@@ -21,5 +21,20 @@ cargo_build_script(
     deps = [
         "@crates//:libc",
         "@crates//:pkg-config",
+    ],
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":libudev-sys",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":libudev-sys",
     ],
 )

--- a/libs/logging/BUILD.bazel
+++ b/libs/logging/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "rust",
@@ -17,6 +17,23 @@ rust_test(
     name = "rust_tests",
     size = "small",
     crate = ":rust",
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":rust",
+        ":rust_tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":rust",
+        ":rust_tests",
+    ],
 )
 
 js_library(

--- a/libs/pdi-scanner/BUILD.bazel
+++ b/libs/pdi-scanner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
 
 rust_binary(
     name = "pdictl",
@@ -77,4 +77,21 @@ rust_test(
     size = "small",
     crate = ":lib",
     tags = ["rust"],
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":lib",
+        ":rust_tests",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":lib",
+        ":rust_tests",
+    ],
 )

--- a/libs/types-rs/BUILD.bazel
+++ b/libs/types-rs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "types-rs",
@@ -17,5 +17,22 @@ rust_test(
     crate = ":types-rs",
     deps = [
         "@crates//:proptest",
+    ],
+)
+
+rust_clippy(
+    name = "clippy",
+    testonly = True,
+    deps = [
+        ":tests",
+        ":types-rs",
+    ],
+)
+
+rustfmt_test(
+    name = "rustfmt",
+    targets = [
+        ":tests",
+        ":types-rs",
     ],
 )


### PR DESCRIPTION
Seeing random rebuilds of rust packages in CI once in a while, with no rs code changes - haven't figured out why and want to try crossing off the possibility of the aspect configuration in the bazelrc triggering a re-analysis re-build somehow.
Might be moot, since AFAICT there was no straightforward way of removing the clippy flags from `ci.bazelrc` without creating a `clippy.toml` with explicit checks listed (`rules_rust`'s `rust_clippy` rule looks for a `clippy.toml`, but not the `clippy` section in `Cargo.toml`)